### PR TITLE
Expose ipc methods rather than ipcRenderer

### DIFF
--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -1,6 +1,11 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
+/*
+ * When exposing a new method make sure to update global.d.ts
+ * (src/renderer/global.d.ts) with the method signature with types
+ * to help out typescipt
+ */
+
 contextBridge.exposeInMainWorld('electron', {
-  // TODO: dont expose whole renderer for security reasons
-  ipcRenderer,
+  requestMediaDialog: () => ipcRenderer.invoke('import-media'),
 });

--- a/src/renderer/components/SelectMediaBlock.tsx
+++ b/src/renderer/components/SelectMediaBlock.tsx
@@ -1,7 +1,6 @@
 import { Box, colors, styled, Typography } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import { Dispatch, SetStateAction } from 'react';
-import requestMediaDialog from '../ipc';
 
 const SelectMediaBox = styled(Box)`
   background: ${colors.grey[400]};
@@ -31,7 +30,7 @@ interface Props {
 
 const SelectMediaBlock = ({ mediaFilePath, setMediaFilePath }: Props) => {
   const selectMedia: () => Promise<void> = async () => {
-    const selectedMedia = await requestMediaDialog();
+    const selectedMedia = await window.electron.requestMediaDialog();
     setMediaFilePath(selectedMedia);
   };
 

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -1,12 +1,10 @@
 // Let TypeScript know that the ipcRenderer is on the window object.
 // If you need to use other modules from electron in the renderer, add their types here and then reference from window.electron
 
-import { IpcRenderer } from 'electron';
-
 declare global {
   interface Window {
     electron: {
-      ipcRenderer: IpcRenderer;
+      requestMediaDialog: () => Promise<string | null>;
     };
   }
 }

--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -1,6 +1,0 @@
-const { ipcRenderer } = window.electron;
-
-const requestMediaDialog: () => Promise<string | null> = () =>
-  ipcRenderer.invoke('import-media');
-
-export default requestMediaDialog;


### PR DESCRIPTION
Note, this change depends on https://github.com/patrickbrett/mlvet/pull/8 as it updates the exposed ipcRenderer.

<hr>

Goal of this PR is to expose methods instead of exposing the entire ipcRenderer


Changes:

- Removed ipc.ts as it declared and exported the `requestMediaDialog` function (`requestMediaDialog` now defined in preload.js)
- Added `requestMediaDialog` and removed `ipcRender` from global.d.ts
- Updates SelectMediaBlock component to use the exposed method rather than the exposed ipcRenderer.