### PR TITLE
Add sleep function back in to simulate transcription

### DIFF
--- a/src/main/transcriptionHandler.ts
+++ b/src/main/transcriptionHandler.ts
@@ -9,9 +9,13 @@ import Transcription from 'sharedTypes/Transcription';
 
 const fs = require('fs');
 
+const sleep: (n: number) => Promise<void> = (n) =>
+  new Promise((resolve) => setTimeout(resolve, n * 1000));
+
 const handleTranscription: (
   fileName: string
 ) => Promise<Transcription> = async () => {
+  await sleep(3); // Sleep to simulate transcription time. Remove this when real transcription is added
   // Read from sample transcript. Replace this section with real transcript input
   const transcriptionPath = app.isPackaged
     ? path.join(process.resourcesPath, 'assets/SampleTranscript.json')


### PR DESCRIPTION
Why is this change needed? 
the sleep method to delay the transcription function was removed previously, so it needs to be re-added to better simulate a transcription
What did you change? 
Re-added the sleep function and called it for 3 seconds in the transcriptionHandler file
