### PR TITLE
Add `savePath` to `baseMockProject` to match the `Project` type

### DIFF
--- a/src/renderer/store/helpers.ts
+++ b/src/renderer/store/helpers.ts
@@ -19,6 +19,7 @@ export interface ApplicationStore {
 const baseMockProject: Omit<Project, 'name'> = {
   schemaVersion: 1,
   mediaType: 'video',
+  savePath: 'fakepath',
   filePath: 'fakepath',
   fileExtension: 'mp4',
   transcription: null,


### PR DESCRIPTION
Changed the `baseMockProject` data type to match the `Project` type.

Error did not stop anything from working. Just making sure everything matches and project is kept neat.