### PR TITLE
fix path to sampletranscript.json in transcriptionhandler.ts

### DIFF
--- a/src/main/handlers/transcriptionHandler.ts
+++ b/src/main/handlers/transcriptionHandler.ts
@@ -19,7 +19,7 @@ const handleTranscription: (
   // Read from sample transcript. Replace this section with real transcript input
   const transcriptionPath = app.isPackaged
     ? path.join(process.resourcesPath, 'assets/SampleTranscript.json')
-    : path.join(__dirname, '../../assets/SampleTranscript.json');
+    : path.join(__dirname, '../../../assets/SampleTranscript.json');
 
   const rawTranscription = fs.readFileSync(transcriptionPath).toString();
   const jsonTranscript = JSON.parse(rawTranscription);


### PR DESCRIPTION
This PR fixes a bug in develop where the simpletranscript.json file can't be opened as transcriptionhandler.ts has been moved so the relative path has been changed. The PR updates the path to point to the correct file from the correct location