### PR TITLE
import `IpcMain` from electron

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -4,6 +4,7 @@ import {
   shell,
   BrowserWindow,
   MenuItemConstructorOptions,
+  IpcMain,
 } from 'electron';
 import { handleOpenProject } from './handlers';
 


### PR DESCRIPTION
`IpcMain` datatype was not found and had to imported from electron. 