### PR TITLE
Refactor pre process logic and add tests

### DIFF
--- a/src/main/editDelete/__tests__/preProcess.test.ts
+++ b/src/main/editDelete/__tests__/preProcess.test.ts
@@ -1,0 +1,102 @@
+import preProcessTranscript from '../preProcess';
+
+describe('Test pre-processing JSON transcript into regular transcript', () => {
+  it('should produce expected transcript when given a JSON transcript', () => {
+    const jsonTranscript = {
+      confidence: 1,
+      words: [
+        {
+          word: 'abc',
+          start_time: 0,
+          duration: 1,
+        },
+        {
+          word: 'def',
+          start_time: 1,
+          duration: 1,
+        },
+      ],
+    };
+    const duration = 2;
+
+    const outputTranscript = preProcessTranscript(jsonTranscript, duration);
+
+    expect(outputTranscript).toEqual({
+      confidence: 1,
+      words: [
+        {
+          deleted: false,
+          duration: 1,
+          fileName: 'PLACEHOLDER FILENAME',
+          key: '0',
+          startTime: 0,
+          word: 'abc',
+        },
+        {
+          deleted: false,
+          duration: 1,
+          fileName: 'PLACEHOLDER FILENAME',
+          key: '1',
+          startTime: 1,
+          word: 'def',
+        },
+      ],
+    });
+  });
+
+  it('should fill blank spaces between words, and between last word and end', () => {
+    const jsonTranscript = {
+      confidence: -7,
+      words: [
+        {
+          word: 'heat',
+          start_time: 5,
+          duration: 2,
+        },
+        {
+          word: 'from',
+          start_time: 8,
+          duration: 3,
+        },
+        {
+          word: 'fire',
+          start_time: 11.2,
+          duration: 0.9,
+        },
+      ],
+    };
+    const duration = 15.77;
+
+    const outputTranscript = preProcessTranscript(jsonTranscript, duration);
+
+    expect(outputTranscript).toEqual({
+      confidence: -7,
+      words: [
+        {
+          deleted: false,
+          duration: 3,
+          fileName: 'PLACEHOLDER FILENAME',
+          key: '0',
+          startTime: 5,
+          word: 'heat',
+        },
+        {
+          deleted: false,
+          duration: 3.2,
+          fileName: 'PLACEHOLDER FILENAME',
+          key: '1',
+          startTime: 8,
+          word: 'from',
+        },
+        {
+          deleted: false,
+          duration: 4.57,
+          fileName: 'PLACEHOLDER FILENAME',
+          key: '2',
+          startTime: 11.2,
+          word: 'fire',
+        },
+      ],
+    });
+  });
+});

--- a/src/main/editDelete/preProcess.ts
+++ b/src/main/editDelete/preProcess.ts
@@ -1,52 +1,80 @@
-import { Transcription, Word } from 'sharedTypes';
+import { MapCallback, roundToMs } from '../util';
+import { Transcription, Word } from '../../sharedTypes';
 
+interface SnakeCaseWord {
+  word: string;
+  duration: number;
+  start_time: number; // TODO: change this to camel case before it touches TS
+}
+
+interface JSONTranscript {
+  confidence: number;
+  words: SnakeCaseWord[];
+}
+
+type PartialWord = Pick<Word, 'word' | 'startTime' | 'duration'>;
+
+/**
+ * Replace the start_time attribute with startTime (can be generalised further but shouldn't
+ * need this once python outputs camelcase anyway)
+ * @param word snake cased partial word
+ * @returns camel cased partial word
+ */
+const camelCase: MapCallback<SnakeCaseWord, PartialWord> = (word) => ({
+  word: word.word,
+  duration: word.duration,
+  startTime: word.start_time,
+});
+
+/**
+ * Adjusts durations so that words last until the next word, or until the end of the transcript
+ * if the last word
+ * @param totalDuration total duration of transcript
+ * @returns word with durations updated
+ */
+const fillDurationGaps: (
+  totalDuration: number
+) => MapCallback<PartialWord, PartialWord> =
+  (totalDuration) => (word, i, words) => {
+    const isLastWord = i === words.length - 1;
+    const durationUntil = isLastWord ? totalDuration : words[i + 1].startTime;
+
+    return {
+      ...word,
+      duration: roundToMs(durationUntil - word.startTime),
+    };
+  };
+
+/**
+ * Injects extra attributes into a PartialWord to make it a full Word -
+ * @param word the word to fill attributes for
+ * @param i index of the word in the transcript
+ * @returns full Word object
+ */
+const injectAttributes: MapCallback<PartialWord, Word> = (word, i) => ({
+  ...word,
+  key: i.toString(),
+  deleted: false,
+  fileName: 'PLACEHOLDER FILENAME',
+});
+
+/**
+ * Pre processes a JSON transcript from python for use in the front end
+ * @param jsonTranscript the JSON transcript input (technically a JS object but with some fields missing)
+ * @param duration duration of the input media file
+ * @returns formatted Transcript object
+ */
 const preProcessTranscript = (
-  jsonTranscript: any,
+  jsonTranscript: JSONTranscript,
   duration: number
 ): Transcription => {
-  const numberOfWords: number = jsonTranscript.words.length;
-
-  const processedTranscript: Transcription = {
+  return {
     confidence: jsonTranscript.confidence,
-    words: [],
+    words: jsonTranscript.words
+      .map(camelCase)
+      .map(fillDurationGaps(duration))
+      .map(injectAttributes),
   };
-
-  for (let i = 0; i < numberOfWords - 1; i += 1) {
-    // duration includes the white space between current and next word
-
-    const wordDuration =
-      jsonTranscript.words[i + 1].start_time -
-      jsonTranscript.words[i].start_time;
-    // unique identifier for each word
-    jsonTranscript.words[i].key = i.toString();
-    const word: Word = {
-      word: jsonTranscript.words[i].word,
-      startTime: jsonTranscript.words[i].start_time,
-      duration: wordDuration,
-      deleted: false,
-      key: i.toString(),
-      fileName: 'PLACEHOLDER FILENAME',
-    };
-
-    processedTranscript.words.push(word);
-  }
-
-  // last word in transcript
-  const wordDuration =
-    duration - jsonTranscript.words[numberOfWords - 1].start_time;
-
-  const lastWord: Word = {
-    word: jsonTranscript.words[numberOfWords - 1].word,
-    startTime: jsonTranscript.words[numberOfWords - 1].start_time,
-    duration: wordDuration,
-    deleted: false,
-    key: (numberOfWords - 1).toString(),
-    fileName: 'PLACEHOLDER FILENAME',
-  };
-
-  processedTranscript.words.push(lastWord);
-
-  return processedTranscript;
 };
 
 export default preProcessTranscript;

--- a/src/main/editDelete/preProcess.ts
+++ b/src/main/editDelete/preProcess.ts
@@ -1,16 +1,6 @@
 import { MapCallback, roundToMs } from '../util';
 import { Transcription, Word } from '../../sharedTypes';
-
-interface SnakeCaseWord {
-  word: string;
-  duration: number;
-  start_time: number; // TODO: change this to camel case before it touches TS
-}
-
-interface JSONTranscript {
-  confidence: number;
-  words: SnakeCaseWord[];
-}
+import { JSONTranscription, SnakeCaseWord } from '../types';
 
 type PartialWord = Pick<Word, 'word' | 'startTime' | 'duration'>;
 
@@ -65,7 +55,7 @@ const injectAttributes: MapCallback<PartialWord, Word> = (word, i) => ({
  * @returns formatted Transcript object
  */
 const preProcessTranscript = (
-  jsonTranscript: JSONTranscript,
+  jsonTranscript: JSONTranscription,
   duration: number
 ): Transcription => {
   return {

--- a/src/main/handlers/transcriptionHandler.ts
+++ b/src/main/handlers/transcriptionHandler.ts
@@ -3,6 +3,11 @@ import fs from 'fs';
 import { app } from 'electron';
 import { Transcription } from '../../sharedTypes';
 import preProcessTranscript from '../editDelete/preProcess';
+import { JSONTranscription, SnakeCaseWord } from '../types';
+
+interface JSONTranscriptionContainer {
+  transcripts: JSONTranscription[];
+}
 
 /**
  * util to simulate running of transcription
@@ -11,6 +16,36 @@ import preProcessTranscript from '../editDelete/preProcess';
  */
 const sleep: (n: number) => Promise<void> = (n) =>
   new Promise((resolve) => setTimeout(resolve, n * 1000));
+
+/**
+ * This is an easy (but kind of annoying) approach to validating incoming JSON.
+ * The idea is that we only have types at compile time, but we need to validate at
+ * runtime. Other solutions include:
+ * 1. Just trust that the JSON is valid, and cast it
+ * 2. More advanced solutions that generate runtime checks based off typescript types
+ * (e.g. https://github.com/YousefED/typescript-json-schema)
+ */
+
+const validateWord = <(word: any) => word is SnakeCaseWord>(
+  ((word) =>
+    typeof word.word === 'string' &&
+    typeof word.duration === 'number' &&
+    typeof word.start_time === 'number')
+);
+
+const validateJsonTranscription = <
+  (transcription: any) => transcription is JSONTranscription
+>((transcription) =>
+  typeof transcription.confidence === 'number' &&
+  Array.isArray(transcription.words) &&
+  transcription.words.every(validateWord));
+
+const validateJsonTranscriptionContainer = <
+  (transcription: any) => transcription is JSONTranscriptionContainer
+>((transcription) =>
+  Array.isArray(transcription.transcripts) &&
+  transcription.transcripts.length === 1 &&
+  validateJsonTranscription(transcription.transcripts[0]));
 
 const handleTranscription: (
   fileName: string
@@ -25,7 +60,9 @@ const handleTranscription: (
   const rawTranscription = fs.readFileSync(transcriptionPath).toString();
   const jsonTranscript = JSON.parse(rawTranscription);
 
-  console.assert(jsonTranscript.transcripts.length === 1); // TODO: add more error handling here
+  if (!validateJsonTranscriptionContainer(jsonTranscript)) {
+    throw new Error('JSON transcript is invalid');
+  }
 
   const duration = 0; // TODO: get actual duration from video
   const processedTranscript = preProcessTranscript(

--- a/src/main/types.d.ts
+++ b/src/main/types.d.ts
@@ -1,1 +1,12 @@
 declare module '@ffprobe-installer/ffprobe';
+
+export interface SnakeCaseWord {
+  word: string;
+  duration: number;
+  start_time: number; // TODO: change this to camel case before it touches TS
+}
+
+export interface JSONTranscription {
+  confidence: number;
+  words: SnakeCaseWord[];
+}

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -39,3 +39,13 @@ export const mkdir = (dirPath: string) => {
 
 export const appDataStoragePath: () => string = () =>
   path.join(app.getPath('userData'), 'mlvet');
+
+// Round a number in seconds to milliseconds - solves a lot of floating point errors
+export const roundToMs: (input: number) => number = (input) =>
+  Math.round(input * 1000) / 1000;
+
+/** Utility types */
+
+// Callback to be passed into a map function.
+// First type argument is the input type, second is the output type
+export type MapCallback<T, U> = (val: T, index: number, arr: T[]) => U;


### PR DESCRIPTION
Origin story: I left a comment on the edit-delete PR suggesting that the pre and post processing logic be refactored to use `map`, but was ambiguous about how.

Riley sent some ideas over message, but to be honest this was a bit too involved to be explained through code snippets - it needed a PR.

I've done the pre process logic as an example - I have left the post process logic for you guys to try. This is a nice-to-have - it makes the code easier to read and easier to modify, but it's not strictly necessary or part of the sprint, so do what you like with this code (including not using it at all if you like) - definitely don't want to stress you out about timelines.

The basic process I followed was:
- Write some unit tests for the existing logic to capture what it's trying to do.
- Think about discrete steps that the logic can be broken down into, and what their inputs and outputs are.
- Try to frame each step as a pure function without any side effects - i.e. takes an input, returns an output, nothing else.
- Write helper types where necessary, and make everything is well typed (e.g. no 'any's).

Also, in doing this I noticed a really minor bug - the floating point subtractions sometimes produce really weird duration values (e.g. 3.199999999993 instead of 3.2), so I've added a util function to round these to the nearest millisecond.

I hope you can follow the same idea for the post processing logic, if you can find some time to do it - it will be a good exercise in writing clean code and contribute to the maintainability of the codebase 🙂  I would be happy to pair on this if that interests any of you.

I think this also serves as a good example of how test driven development can be useful for very back-end problems like this one.