### PR TITLE
enable auto focus on textfield when user selects to create new project

### DIFF
--- a/src/renderer/components/NewProjectModal/NewProjectView.tsx
+++ b/src/renderer/components/NewProjectModal/NewProjectView.tsx
@@ -113,6 +113,7 @@ const NewProjectView = ({ closeModal, nextView }: Props) => {
             label="Project Name"
             value={projectName}
             onChange={(event) => handleProjectNameInput(event)}
+            autoFocus
           />
         </CustomStack>
         <CustomRowStack sx={{ alignItems: 'flex-end', gap: '32px' }}>


### PR DESCRIPTION
## What changed:
- When a user selects `New project` the modal will pop up as normal but now with the cursor focused on the TextField component.

## Why has this change been made?

Since we will be adding functionality to navigate between modal views using the `enter` key soon (soon, like in this PR #49) it makes sense to just already be focused on the textfield such that the user can type, hit enter, import video, hit enter. without touching the mouse.

## Here is what it looks like:

![image](https://user-images.githubusercontent.com/86769131/167335347-8c779b20-8222-43ff-b038-0970fdecafbd.png)
