### PR TITLE
Some cleanups

### DIFF
--- a/src/main/handlers/index.ts
+++ b/src/main/handlers/index.ts
@@ -5,6 +5,7 @@ import handleTranscription_ from './transcriptionHandler';
 import extractThumbnail_ from './thumbnailExtract';
 import retrieveProjectMetadata_ from './projectMetadataHandler';
 import showImportMediaDialog_ from './fileDialog';
+import handleOsQuery_ from './osQuery';
 
 export {
   readRecentProjects,
@@ -20,3 +21,4 @@ export const handleTranscription = handleTranscription_;
 export const extractThumbnail = extractThumbnail_;
 export const retrieveProjectMetadata = retrieveProjectMetadata_;
 export const showImportMediaDialog = showImportMediaDialog_;
+export const handleOsQuery = handleOsQuery_;

--- a/src/main/handlers/osQuery.ts
+++ b/src/main/handlers/osQuery.ts
@@ -1,0 +1,22 @@
+import os from 'os';
+import { OperatingSystems } from '../../sharedTypes';
+
+export const handleOsQuery: () => OperatingSystems | null = () => {
+  const isDarwin = os.platform() === OperatingSystems.MACOS;
+  const isWindows = os.platform() === OperatingSystems.WINDOWS;
+  const isLinux = os.platform() === OperatingSystems.LINUX;
+
+  if (isDarwin) {
+    return OperatingSystems.MACOS;
+  }
+  if (isWindows) {
+    return OperatingSystems.WINDOWS;
+  }
+  if (isLinux) {
+    return OperatingSystems.LINUX;
+  }
+
+  return null;
+};
+
+export default handleOsQuery;

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -8,6 +8,7 @@ import {
   readRecentProjects,
   writeRecentProjects,
   retrieveProjectMetadata,
+  handleOsQuery,
 } from './handlers';
 
 const initialiseIpcHandlers: (mainWindow: BrowserWindow) => void = (
@@ -38,6 +39,8 @@ const initialiseIpcHandlers: (mainWindow: BrowserWindow) => void = (
   ipcMain.handle('retrieve-project-metadata', async (_event, project) =>
     retrieveProjectMetadata(project)
   );
+
+  ipcMain.handle('user-os', async () => handleOsQuery());
 };
 
 export default initialiseIpcHandlers;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -17,12 +17,7 @@ import { get } from 'http';
 import path from 'path';
 import MenuBuilder from './menu';
 import startServer from './pyServer';
-import {
-  appDataStoragePath,
-  mkdir,
-  resolveHtmlPath,
-  handleOSQuery,
-} from './util';
+import { appDataStoragePath, mkdir, resolveHtmlPath } from './util';
 import initialiseIpcHandlers from './ipc';
 import { extractAudio } from './handlers';
 
@@ -40,8 +35,6 @@ dotenv.config();
 
 // If app data storage path doesn't exist, create it
 mkdir(appDataStoragePath());
-
-ipcMain.handle('user-os', async () => handleOSQuery());
 
 if (process.env.NODE_ENV === 'production') {
   const sourceMapSupport = require('source-map-support');

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -42,29 +42,43 @@ export default class MenuBuilder {
     return menu;
   }
 
+  setButtonEnabled: (
+    menu: Menu,
+    submenuId: string,
+    itemId: string,
+    enabled: boolean
+  ) => void = (menu, submenuId, itemId, isEnabled) => {
+    const foundSubmenu = menu.items.find((submenu) => submenu.id === submenuId);
+
+    if (!foundSubmenu) {
+      return;
+    }
+
+    const button = foundSubmenu.submenu?.items.find(
+      (item) => item.id === itemId
+    );
+
+    if (!button) {
+      return;
+    }
+
+    button.enabled = isEnabled;
+  };
+
   setListeners: (menu: Menu, ipcMain: IpcMain) => void = (menu, ipcMain) => {
+    ipcMain.handle(
+      'set-save-enabled',
+      (_event, saveEnabled: boolean, saveAsEnabled: boolean) => {
+        this.setButtonEnabled(menu, 'file', 'save', saveEnabled);
+        this.setButtonEnabled(menu, 'file', 'saveAs', saveAsEnabled);
+      }
+    );
+
     ipcMain.handle(
       'set-undo-redo-enabled',
       (_event, undoEnabled: boolean, redoEnabled: boolean) => {
-        const editSubmenu = menu.items.find((submenu) => submenu.id === 'edit');
-
-        if (!editSubmenu) {
-          return;
-        }
-
-        const undoButton = editSubmenu.submenu?.items.find(
-          (item) => item.id === 'undo'
-        );
-        const redoButton = editSubmenu.submenu?.items.find(
-          (item) => item.id === 'redo'
-        );
-
-        if (!undoButton || !redoButton) {
-          return;
-        }
-
-        undoButton.enabled = undoEnabled;
-        redoButton.enabled = redoEnabled;
+        this.setButtonEnabled(menu, 'edit', 'undo', undoEnabled);
+        this.setButtonEnabled(menu, 'edit', 'redo', redoEnabled);
       }
     );
   };
@@ -109,6 +123,43 @@ export default class MenuBuilder {
     ];
   }
 
+  buildFileOptions(): MenuItemConstructorOptions[] {
+    return [
+      {
+        id: 'open',
+        label: 'Open...',
+        accelerator: 'CommandOrControl+O',
+        click: async () => {
+          const { project, filePath } = await handleOpenProject(
+            this.mainWindow
+          );
+
+          this.mainWindow.webContents.send('project-opened', project, filePath);
+        },
+      },
+      {
+        id: 'save',
+        label: 'Save',
+        accelerator: 'CommandOrControl+S',
+        click: () => {
+          // Tell the renderer to initiate a save
+          this.mainWindow.webContents.send('initiate-save-project');
+        },
+        enabled: false,
+      },
+      {
+        id: 'saveAs',
+        label: 'Save As...',
+        accelerator: 'CommandOrControl+Shift+S',
+        click: () => {
+          // Tell the renderer to initiate a save-as
+          this.mainWindow.webContents.send('initiate-save-as-project');
+        },
+        enabled: false,
+      },
+    ];
+  }
+
   buildDarwinTemplate(): MenuItemConstructorOptions[] {
     const subMenuAbout: DarwinMenuItemConstructorOptions = {
       label: 'MLVET',
@@ -141,32 +192,9 @@ export default class MenuBuilder {
     };
 
     const subMenuFile: DarwinMenuItemConstructorOptions = {
+      id: 'file',
       label: 'File',
-      submenu: [
-        {
-          label: 'Save Project',
-          accelerator: 'CommandOrControl+S',
-          click: () => {
-            // Tell the renderer to initiate a save
-            this.mainWindow.webContents.send('initiate-save-project');
-          },
-        },
-        {
-          label: 'Open Project',
-          accelerator: 'CommandOrControl+O',
-          click: async () => {
-            const { project, filePath } = await handleOpenProject(
-              this.mainWindow
-            );
-
-            this.mainWindow.webContents.send(
-              'project-opened',
-              project,
-              filePath
-            );
-          },
-        },
-      ],
+      submenu: this.buildFileOptions(),
     };
 
     const subMenuEdit: DarwinMenuItemConstructorOptions = {
@@ -259,19 +287,7 @@ export default class MenuBuilder {
     const templateDefault = [
       {
         label: '&File',
-        submenu: [
-          {
-            label: '&Open',
-            accelerator: 'Ctrl+O',
-          },
-          {
-            label: '&Close',
-            accelerator: 'Ctrl+W',
-            click: () => {
-              this.mainWindow.close();
-            },
-          },
-        ],
+        submenu: this.buildFileOptions(),
       },
       {
         id: 'edit',

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -39,24 +39,6 @@ export const mkdir = (dirPath: string) => {
   }
 };
 
-export const handleOSQuery: () => OperatingSystems | null = () => {
-  const isDarwin = os.platform() === OperatingSystems.MACOS;
-  const isWindows = os.platform() === OperatingSystems.WINDOWS;
-  const isLinux = os.platform() === OperatingSystems.LINUX;
-
-  if (isDarwin) {
-    return OperatingSystems.MACOS;
-  }
-  if (isWindows) {
-    return OperatingSystems.WINDOWS;
-  }
-  if (isLinux) {
-    return OperatingSystems.LINUX;
-  }
-
-  return null;
-};
-
 export const appDataStoragePath: () => string = () =>
   path.join(app.getPath('userData'), 'mlvet');
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,16 +1,14 @@
 import { Box, CssBaseline, styled, ThemeProvider } from '@mui/material';
-import { ReactElement, useEffect, useState } from 'react';
-import { Provider, useDispatch, useSelector } from 'react-redux';
+import { ReactElement } from 'react';
+import { Provider, useSelector } from 'react-redux';
 import './App.css';
 import colors from './colors';
 import HomePage from './pages/Home';
 import ProjectPage from './pages/Project';
-import { recentProjectsLoaded } from './store/actions';
 import { ApplicationPage, ApplicationStore } from './store/helpers';
 import applicationStore from './store/store';
+import StoreChangeObserver from './StoreChangeObserver';
 import theme from './theme';
-
-const { readRecentProjects, writeRecentProjects } = window.electron;
 
 const RootContainer = styled(Box)`
   margin: 0;
@@ -29,44 +27,6 @@ function Router() {
   };
 
   return pageComponents[currentPage];
-}
-
-function StoreChangeObserver() {
-  const recentProjects = useSelector(
-    (store: ApplicationStore) => store.recentProjects
-  );
-
-  const [hasLoadedRecentProjects, setHasLoadedRecentProjects] =
-    useState<boolean>(false);
-
-  const dispatch = useDispatch();
-
-  // Load the recent projects from the back end when the app starts
-  useEffect(() => {
-    // Only load if we haven't yet for this app load
-    if (hasLoadedRecentProjects) {
-      return;
-    }
-
-    (async () => {
-      const loadedRecentProjects = await readRecentProjects();
-      dispatch(recentProjectsLoaded(loadedRecentProjects));
-      setHasLoadedRecentProjects(true);
-    })();
-  }, [hasLoadedRecentProjects, setHasLoadedRecentProjects, dispatch]);
-
-  // Persist the recent projects in the back end when the recentProjects changes in the store
-  useEffect(() => {
-    // If we haven't read yet, don't write
-    if (!hasLoadedRecentProjects) {
-      return;
-    }
-
-    writeRecentProjects(recentProjects);
-  }, [recentProjects, hasLoadedRecentProjects]);
-
-  // Component doesn't render anything
-  return null;
 }
 
 export default function App() {

--- a/src/renderer/StoreChangeObserver.tsx
+++ b/src/renderer/StoreChangeObserver.tsx
@@ -1,0 +1,44 @@
+import { useState, useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { recentProjectsLoaded } from './store/actions';
+import { ApplicationStore } from './store/helpers';
+
+const { readRecentProjects, writeRecentProjects } = window.electron;
+
+export default function StoreChangeObserver() {
+  const recentProjects = useSelector(
+    (store: ApplicationStore) => store.recentProjects
+  );
+
+  const [hasLoadedRecentProjects, setHasLoadedRecentProjects] =
+    useState<boolean>(false);
+
+  const dispatch = useDispatch();
+
+  // Load the recent projects from the back end when the app starts
+  useEffect(() => {
+    // Only load if we haven't yet for this app load
+    if (hasLoadedRecentProjects) {
+      return;
+    }
+
+    (async () => {
+      const loadedRecentProjects = await readRecentProjects();
+      dispatch(recentProjectsLoaded(loadedRecentProjects));
+      setHasLoadedRecentProjects(true);
+    })();
+  }, [hasLoadedRecentProjects, setHasLoadedRecentProjects, dispatch]);
+
+  // Persist the recent projects in the back end when the recentProjects changes in the store
+  useEffect(() => {
+    // If we haven't read yet, don't write
+    if (!hasLoadedRecentProjects) {
+      return;
+    }
+
+    writeRecentProjects(recentProjects);
+  }, [recentProjects, hasLoadedRecentProjects]);
+
+  // Component doesn't render anything
+  return null;
+}

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -7,6 +7,7 @@ import {
   ProjectMetadata,
   Transcription,
   OperatingSystems,
+  RecentProject,
 } from '../sharedTypes';
 
 declare global {
@@ -19,8 +20,8 @@ declare global {
       setUndoRedoEnabled: (undoEnabled: boolean, redoEnabled: boolean) => void;
       extractThumbnail: (filePath: string) => Promise<string>;
       userOS: () => Promise<OperatingSystems>;
-      readRecentProjects: () => Promise<Project[]>;
-      writeRecentProjects: (recentProjects: Project[]) => Promise<void>;
+      readRecentProjects: () => Promise<RecentProject[]>;
+      writeRecentProjects: (recentProjects: RecentProject[]) => Promise<void>;
       retrieveProjectMetadata: (project: Project) => Promise<ProjectMetadata>;
 
       on: (

--- a/src/renderer/pages/Project.tsx
+++ b/src/renderer/pages/Project.tsx
@@ -5,12 +5,7 @@ import TranscriptionBlock from 'renderer/components/TranscriptionBlock';
 import { transcriptionCreated } from 'renderer/store/actions';
 import { Transcription } from 'sharedTypes';
 import ExportCard from '../components/ExportCard';
-import { dispatchOp } from '../store/opHelpers';
 import { ApplicationStore } from '../store/helpers';
-import {
-  makeChangeWordToSwampOp,
-  makeDeleteEverySecondWordOp,
-} from '../store/ops';
 
 /*
 This is the page that gets displayed while you are editing a video.
@@ -26,8 +21,6 @@ const ProjectPage = () => {
   const { isExporting, exportProgress } = useSelector(
     (store: ApplicationStore) => store.exportIo
   );
-
-  const undoStack = useSelector((store: ApplicationStore) => store.undoStack);
 
   // RK: I really shouldn't use transcriptionCreated here - but i'm lazy and it works
   const saveTranscription: (transcription: Transcription) => void = useCallback(
@@ -86,28 +79,6 @@ const ProjectPage = () => {
   const onWordClick = (wordIndex: number) => {
     // TODO: Implement onWordClick
     return currentProject.transcription?.words[wordIndex];
-  };
-
-  const deleteEverySecondWord: () => void = () => {
-    if (currentProject.transcription === null) {
-      return;
-    }
-
-    dispatchOp(makeDeleteEverySecondWordOp(currentProject.transcription));
-  };
-
-  const changeRandomWordToSwamp: () => void = () => {
-    if (currentProject.transcription === null) {
-      return;
-    }
-
-    const wordIndex = Math.floor(
-      Math.random() * currentProject.transcription.words.length
-    );
-
-    dispatchOp(
-      makeChangeWordToSwampOp(currentProject.transcription, wordIndex)
-    );
   };
 
   return (


### PR DESCRIPTION
A few misc cleanups needed before I can get my save/save as change in - otherwise cohesiveness of that PR is pretty terrible

Changes:
- Move osQuery into handlers, use ipc.ts to register it like the other handlers
- Abstract out the button enable/disable logic in the menu
- Move the StoreChangeObserver out of app.tsx and into its own file
- Clean up project.tsx to remove dummy undo stack demo functions