### PR TITLE
EDL Export Cut Number Bugfix

### DIFF
--- a/src/main/export.ts
+++ b/src/main/export.ts
@@ -23,7 +23,7 @@ const constructEDL: (
   const entries = words.length;
   output += words
     .map((word, i) => {
-      const edlEntry = `${padZeros(i + 1, entries)}\tAX\tAA/V\tC`;
+      const edlEntry = `${padZeros(i + 1, Math.floor(Math.log10(entries)) + 1)}\tAX\tAA/V\tC`;
 
       const editStart = secondToTimestamp(word.startTime);
       const editEnd = secondToTimestamp(word.startTime + word.duration);


### PR DESCRIPTION
Fixed a bug where the cut number in the EDL isn't padded by the correct number of zeros.

It used to do something like:
`00000000000014 AX AA/V C    00:00:12:10    00:00:13:01`

Now it looks like:
`014 AX AA/V C    00:00:12:10    00:00:13:01`

Literally like a dozen characters of code.