### PR TITLE
Extract audio after media is imported 

### DIFF
--- a/src/main/handlers/audioExtract.ts
+++ b/src/main/handlers/audioExtract.ts
@@ -1,22 +1,29 @@
 import path from 'path';
 import { path as ffmpegPath } from '@ffmpeg-installer/ffmpeg';
 import ffmpeg from 'fluent-ffmpeg';
+import { Project } from 'sharedTypes';
+import { audioExtractStoragePath, mkdir } from '../util';
 
 ffmpeg.setFfmpegPath(ffmpegPath);
 
-export default function extractAudio(
-  absolutePathToMediaFile: string
-): Promise<string> {
+export default function extractAudio(project: Project): Promise<string> {
+  if (project.mediaFilePath === null || project.id === null) {
+    return new Promise((_resolve, reject) => {
+      const errorMessage = 'Project mediaFilePath or ID cannot be null';
+      reject(errorMessage);
+    });
+  }
+
+  mkdir(audioExtractStoragePath());
+
   const pathToSaveMedia = path.join(
-    process.cwd(),
-    'assets',
-    'audio',
-    'audio.wav'
+    audioExtractStoragePath(),
+    `${project.id}.wav`
   );
 
   console.log('Started audio extraction');
 
-  const command = ffmpeg(absolutePathToMediaFile)
+  const command = ffmpeg(project.mediaFilePath)
     .audioChannels(1)
     .outputOptions('-ar 16000') // Sample rate of 16kHz
     .noVideo()

--- a/src/main/handlers/transcriptionHandler.ts
+++ b/src/main/handlers/transcriptionHandler.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import fs from 'fs';
 import { app } from 'electron';
 import getAudioDurationInSeconds from 'get-audio-duration';
-import { Transcription } from '../../sharedTypes';
+import { Project, Transcription } from '../../sharedTypes';
 import preProcessTranscript from '../editDelete/preProcess';
 import { JSONTranscription, SnakeCaseWord } from '../types';
 
@@ -49,9 +49,13 @@ const validateJsonTranscriptionContainer = <
   validateJsonTranscription(transcription.transcripts[0]));
 
 const handleTranscription: (
-  filePath: string
-) => Promise<Transcription> = async (filePath: string) => {
+  project: Project
+) => Promise<Transcription | null> = async (project: Project) => {
   // TODO: replace hard coded media path with parameter passed in
+
+  if (project.audioExtractFilePath == null || project.mediaFilePath == null) {
+    return null;
+  }
 
   await sleep(3); // Sleep to simulate transcription time. Remove this when real transcription is added
 
@@ -67,15 +71,9 @@ const handleTranscription: (
     throw new Error('JSON transcript is invalid');
   }
 
-  const pathToSaveMedia = path.join(
-    process.cwd(),
-    'assets',
-    'audio',
-    'audio.wav'
-  );
   const duration: number =
-    (await getAudioDurationInSeconds(pathToSaveMedia)) || 0;
-  const fileName = path.basename(filePath);
+    (await getAudioDurationInSeconds(project.audioExtractFilePath)) || 0;
+  const fileName = path.basename(project.mediaFilePath);
   const processedTranscript = preProcessTranscript(
     jsonTranscript.transcripts[0],
     duration,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -17,8 +17,8 @@ const initialiseIpcHandlers: (mainWindow: BrowserWindow) => void = (
 ) => {
   ipcMain.handle('import-media', () => showImportMediaDialog(mainWindow));
 
-  ipcMain.handle('transcribe-media', async (_event, filePath) =>
-    handleTranscription(filePath)
+  ipcMain.handle('transcribe-media', async (_event, project) =>
+    handleTranscription(project)
   );
 
   ipcMain.handle('extract-thumbnail', async (_event, filePath) =>

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -3,6 +3,7 @@ import showImportMediaDialog from './handlers/fileDialog';
 import {
   handleTranscription,
   extractThumbnail,
+  extractAudio,
   handleSaveProject,
   handleOpenProject,
   readRecentProjects,
@@ -41,6 +42,10 @@ const initialiseIpcHandlers: (mainWindow: BrowserWindow) => void = (
   );
 
   ipcMain.handle('user-os', async () => handleOsQuery());
+
+  ipcMain.handle('extract-audio', async (_event, project) =>
+    extractAudio(project)
+  );
 };
 
 export default initialiseIpcHandlers;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -19,7 +19,6 @@ import MenuBuilder from './menu';
 import startServer from './pyServer';
 import { appDataStoragePath, mkdir, resolveHtmlPath } from './util';
 import initialiseIpcHandlers from './ipc';
-import { extractAudio } from './handlers';
 
 export default class AppUpdater {
   constructor() {
@@ -98,11 +97,6 @@ const createWindow = async () => {
     } else {
       mainWindow.show();
     }
-
-    const extractedPath = await extractAudio(
-      path.join(process.cwd(), 'assets/videos/demo-video.mp4')
-    );
-    console.log(`Extracted audio to: ${extractedPath}`);
 
     pyServer = startServer();
 

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -22,7 +22,7 @@ contextBridge.exposeInMainWorld('electron', {
     ipcRenderer.invoke('write-recent-projects', recentProjects),
   retrieveProjectMetadata: (project) =>
     ipcRenderer.invoke('retrieve-project-metadata', project),
-
+  extractAudio: (project) => ipcRenderer.invoke('extract-audio', project),
   // Have to manually redefine, otherwise Electron nukes this since main->renderer comms is not a standard use case
   on(channel, listener) {
     return ipcRenderer.on(channel, listener);

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -8,8 +8,8 @@ const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('electron', {
   requestMediaDialog: () => ipcRenderer.invoke('import-media'),
-  requestTranscription: (filePath) =>
-    ipcRenderer.invoke('transcribe-media', filePath),
+  requestTranscription: (project) =>
+    ipcRenderer.invoke('transcribe-media', project),
   saveProject: (project) => ipcRenderer.invoke('save-project', project),
   openProject: () => ipcRenderer.invoke('open-project'),
   setUndoRedoEnabled: (undoEnabled, redoEnabled) =>

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -40,6 +40,9 @@ export const mkdir = (dirPath: string) => {
 export const appDataStoragePath: () => string = () =>
   path.join(app.getPath('userData'), 'mlvet');
 
+export const audioExtractStoragePath: () => string = () =>
+  path.join(appDataStoragePath(), 'audioExtracts');
+
 // Round a number in seconds to milliseconds - solves a lot of floating point errors
 export const roundToMs: (input: number) => number = (input) =>
   Math.round(input * 1000) / 1000;

--- a/src/renderer/components/NewProjectModal/ImportMediaView.tsx
+++ b/src/renderer/components/NewProjectModal/ImportMediaView.tsx
@@ -7,11 +7,14 @@ import IconButton from '@mui/material/IconButton';
 import { ApplicationStore } from 'renderer/store/helpers';
 import { projectCreated, recentProjectAdded } from 'renderer/store/actions';
 import { Project } from 'sharedTypes';
-import { updateProjectWithMedia } from 'renderer/util';
+import {
+  updateProjectWithMedia,
+  updateProjectWithExtractedAudio,
+} from 'renderer/util';
 import SelectMediaBlock from '../SelectMediaBlock';
 import MediaDisplayOnImport from '../MediaDisplayOnImport';
 
-const { retrieveProjectMetadata } = window.electron;
+const { retrieveProjectMetadata, extractAudio } = window.electron;
 
 interface Props {
   prevView: () => void;
@@ -64,14 +67,32 @@ const ImportMediaView = ({ prevView, closeModal, nextView }: Props) => {
   };
 
   const handleTranscribe = async () => {
-    const project = await updateProjectWithMedia(currentProject, mediaFilePath);
-
-    if (project === null || mediaFilePath === null) {
+    if (mediaFilePath === null) {
       return;
     }
 
-    setCurrentProject(project);
-    await addToRecentProjects(project);
+    const projectWithMedia = await updateProjectWithMedia(
+      currentProject,
+      mediaFilePath
+    );
+
+    if (projectWithMedia === null) {
+      return;
+    }
+
+    const audioFilePath = await extractAudio(projectWithMedia);
+
+    const projectWithAudioExtract = await updateProjectWithExtractedAudio(
+      projectWithMedia,
+      audioFilePath
+    );
+
+    if (projectWithAudioExtract === null) {
+      return;
+    }
+
+    setCurrentProject(projectWithAudioExtract);
+    await addToRecentProjects(projectWithAudioExtract);
 
     nextView();
   };

--- a/src/renderer/components/NewProjectModal/RunTranscriptionView.tsx
+++ b/src/renderer/components/NewProjectModal/RunTranscriptionView.tsx
@@ -10,6 +10,8 @@ import { ApplicationStore } from '../../store/helpers';
 import { Transcription, AsyncState } from '../../../sharedTypes';
 import MediaDisplayTranscribeProgress from '../MediaDisplayTranscribeProgress';
 
+const { requestTranscription } = window.electron;
+
 const CustomStack = styled(Stack)`
   width: 100%;
 `;
@@ -62,9 +64,12 @@ const RunTranscriptionView = ({ closeModal, nextView }: Props) => {
 
     setAsyncState(AsyncState.LOADING);
 
-    window.electron
-      .requestTranscription(currentProject.mediaFilePath)
+    requestTranscription(currentProject)
       .then((transcription) => {
+        if (transcription === null) {
+          return null;
+        }
+
         setAsyncState(AsyncState.DONE);
         setTranscription(transcription);
         return null;

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -23,6 +23,7 @@ declare global {
       readRecentProjects: () => Promise<RecentProject[]>;
       writeRecentProjects: (recentProjects: RecentProject[]) => Promise<void>;
       retrieveProjectMetadata: (project: Project) => Promise<ProjectMetadata>;
+      extractAudio: (project: Project) => Promise<string>;
 
       on: (
         channel: string,

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -14,7 +14,7 @@ declare global {
   interface Window {
     electron: {
       requestMediaDialog: () => Promise<string | null>;
-      requestTranscription: (filePath: string) => Promise<Transcription>;
+      requestTranscription: (project: Project) => Promise<Transcription | null>;
       saveProject: (project: Project) => Promise<string>; // Returns the file path
       openProject: () => Promise<{ project: Project; filePath: string }>;
       setUndoRedoEnabled: (undoEnabled: boolean, redoEnabled: boolean) => void;

--- a/src/renderer/util.ts
+++ b/src/renderer/util.ts
@@ -101,6 +101,7 @@ export const makeProject: (
     thumbnailFilePath: thumbnailPath,
     projectFilePath: null,
     exportFilePath: null,
+    audioExtractFilePath: null,
   };
 
   return project;
@@ -120,6 +121,7 @@ export const makeProjectWithoutMedia: (
     mediaType: 'audio',
     mediaFileExtension: 'mp3',
     thumbnailFilePath: null,
+    audioExtractFilePath: null,
   };
 
   return project;
@@ -156,6 +158,23 @@ export const updateProjectWithMedia: (
   currentProject.schemaVersion = CURRENT_SCHEMA_VERSION;
   currentProject.transcription = null;
   currentProject.thumbnailFilePath = thumbnailPath;
+  currentProject.audioExtractFilePath = null;
+
+  return currentProject;
+};
+
+export const updateProjectWithExtractedAudio: (
+  currentProject: Project,
+  extractedAudioFilePath: string | null
+) => Promise<Project | null> = async (
+  currentProject,
+  extractedAudioFilePath
+) => {
+  if (extractedAudioFilePath === null) {
+    return null;
+  }
+
+  currentProject.audioExtractFilePath = extractedAudioFilePath;
 
   return currentProject;
 };

--- a/src/sharedTypes.ts
+++ b/src/sharedTypes.ts
@@ -4,6 +4,7 @@ export interface Project {
   name: string;
   projectFilePath: string | null;
   exportFilePath: string | null;
+  audioExtractFilePath: string | null;
   mediaFilePath: string | null;
   transcription: Transcription | null;
   mediaType: 'audio' | 'video';


### PR DESCRIPTION
### Why is this change needed?
- The app requires the audio of the imported media to be available for use.

### Some context
- Before this PR audio extract was just a function being called when the app started (this was a demo when Patrick and I worked on that initial feature)

### What did I change?
- I changed the implementation the `extractAudio` function which now takes in a project as input rather than (simply because the project object has the fields that are required by the method at that stage).
- Now saves the extracted audio under `mlvet/extractedAudio/<project-id>.wav`
    - I used the `project id` as the name for the audio file instead of project name since it is unique and we will never have to deal with `project id` changing

### reviewers
Justin, because he brought this up during the SA meeting + his work depends on it
Kate, because she also works on the transcription team
Dan, because i've never had him in any of my PR's before