### PR TITLE
Link video preview FE with express server

### DIFF
--- a/package.json
+++ b/package.json
@@ -206,6 +206,7 @@
     "@fontsource/rubik": "^4.5.6",
     "@mui/icons-material": "^5.5.1",
     "@mui/material": "^5.5.1",
+    "buffer": "^6.0.3",
     "child_process": "^1.0.2",
     "dotenv": "^16.0.0",
     "electron-debug": "^3.2.0",
@@ -219,9 +220,9 @@
     "react-dom": "^17.0.2",
     "react-redux": "^7.2.6",
     "redux": "^4.1.2",
+    "socket.io-client": "^4.5.0",
     "uuid": "^8.3.2",
-    "vimond-replay": "^3.3.0",
-    "socket.io-client": "^4.5.0"
+    "vimond-replay": "^3.3.0"
   },
   "devEngines": {
     "node": "16.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2530,6 +2530,14 @@ buffer@^5.1.0, buffer@^5.5.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
+
 builder-util-runtime@8.8.1:
   version "8.8.1"
   resolved "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.8.1.tgz"
@@ -5247,7 +5255,7 @@ identity-obj-proxy@^3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-ieee754@^1.1.13:
+ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==


### PR DESCRIPTION
## Summary

Links the video preview frontend to the express streaming server backend.

<hr/>

### What did you change?

Changed the `VideoPreviewController.tsx` to access the input media file path from redux and send it to the express server on the backend. Also, added the [`buffer` package](https://www.npmjs.com/package/buffer) (MIT license)

<hr/>

### Notes

I added a new package `buffer`. This package allows us to encode strings to base64 on the client side of the app (native Buffer only exists in Node.js backend). We use this to encode the media file path for the project so that it can be sent to the backend in the API URI.
There are other methods of encoding strings but most are hacky or deprecated.

<hr/>

### Testing

Just transcribe a video as usual, except now the video preview will also show that video.