### PR TITLE
Project page opens again after finishing export

### DIFF
--- a/src/main/export/export.ts
+++ b/src/main/export/export.ts
@@ -74,7 +74,11 @@ export const exportEDL: (
         mainWindow
       )
     );
-    mainWindow?.webContents.send('finish-export', 1);
+    mainWindow?.webContents.send(
+      'finish-export',
+      project,
+      project.projectFilePath
+    );
   }
 };
 

--- a/src/renderer/ipcRegistration.ts
+++ b/src/renderer/ipcRegistration.ts
@@ -95,8 +95,9 @@ ipc.on('export-progress-update', async (_event, progress: number) => {
 /**
  * Used by backend to notify frontend that export is complete
  */
-ipc.on('finish-export', async () => {
-  store.dispatch(finishExport());
+ipc.on('finish-export', async (_event, project: Project, filePath: string) => {
+  store.dispatch(finishExport(project, filePath));
+  store.dispatch(pageChanged(ApplicationPage.PROJECT));
 });
 
 /*

--- a/src/renderer/store/currentProject/reducer.ts
+++ b/src/renderer/store/currentProject/reducer.ts
@@ -66,7 +66,10 @@ const currentProjectReducer: Reducer<
   }
 
   if (action.type === FINISH_EXPORT) {
-    return null;
+    return {
+      ...(action.payload.project as Project),
+      projectFilePath: action.payload.filePath,
+    };
   }
 
   // Delegate transcription-related actions to transcription reducer

--- a/src/renderer/store/exportIo/actions.ts
+++ b/src/renderer/store/exportIo/actions.ts
@@ -1,3 +1,4 @@
+import { Project } from 'sharedTypes';
 import { Action } from '../action';
 
 export const START_EXPORT = 'START_EXPORT';
@@ -22,7 +23,13 @@ export const updateExportProgress: (progress: number) => Action<number> = (
   payload: progress,
 });
 
-export const finishExport: () => Action<null> = () => ({
+export const finishExport: (
+  project: Project,
+  filePath: string | null
+) => Action<{ project: Project; filePath: string | null }> = (
+  project,
+  filePath
+) => ({
   type: FINISH_EXPORT,
-  payload: null,
+  payload: { project, filePath },
 });


### PR DESCRIPTION
<!-- Notes!
    Please do not forget to:
        1. assign some one to review your pull request!
        2. did you include unit tests?
        3. did you merge develop into your branch?
        4. notify the #pr channel on slack!

    Feel free to remove the sections which you do not fill out
 -->

## Summary

<!-- Provide a summary of what your changes achieve aka what the goal of the PR is -->

<hr/>
The project page opens up again after export is finished

### Why is this change needed?

<hr/>

It fixes a bug. After finishing export, the current project page was not being opened.

### What did you change?

<hr/>

Modified the finishExport action so that it updates the currentProject. 
pageChanged action is dispatched with the current Project after dispatching finishProject.

### Does it depend on any other changes/PRs?

<hr/>
No

### Screenshots of UI changes, if any

<hr/>
NA

### OS

<!-- To select your OS. Place an 'x' within [ ]. eg. - [x] Linux -->

- [ ] Linux
- [ ] MacOS
- [x] Windows
