### PR TITLE
Highlight words on playback

### DIFF
--- a/src/renderer/components/TranscriptionBlock.tsx
+++ b/src/renderer/components/TranscriptionBlock.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { Box } from '@mui/material';
+import { useEffect, useState } from 'react';
 import { Transcription } from 'sharedTypes';
 import colors from '../colors';
 
@@ -30,15 +31,27 @@ const Word = styled('span')`
 
 interface Props {
   transcription: Transcription;
-  nowPlayingWordIndex: number | null;
+  time: number;
   onWordClick: (wordIndex: number) => void;
 }
 
-const TranscriptionBlock = ({
-  onWordClick,
-  transcription,
-  nowPlayingWordIndex,
-}: Props) => {
+const TranscriptionBlock = ({ onWordClick, transcription, time }: Props) => {
+  const [nowPlayingWordIndex, setNowPlayingWordIndex] = useState<number | null>(
+    null
+  );
+
+  useEffect(() => {
+    const newPlayingWordIndex = transcription.words.findIndex(
+      (word) =>
+        time >= word.outputStartTime &&
+        time <= word.outputStartTime + word.duration &&
+        !word.deleted
+    );
+    if (newPlayingWordIndex !== nowPlayingWordIndex)
+      setNowPlayingWordIndex(newPlayingWordIndex);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [time, transcription]);
+
   return (
     <TranscriptionBox>
       <p

--- a/src/renderer/components/TranscriptionBlock.tsx
+++ b/src/renderer/components/TranscriptionBlock.tsx
@@ -30,10 +30,15 @@ const Word = styled('span')`
 
 interface Props {
   transcription: Transcription;
+  nowPlayingWordIndex: number | null;
   onWordClick: (wordIndex: number) => void;
 }
 
-const TranscriptionBlock = ({ onWordClick, transcription }: Props) => {
+const TranscriptionBlock = ({
+  onWordClick,
+  transcription,
+  nowPlayingWordIndex,
+}: Props) => {
   return (
     <TranscriptionBox>
       <p
@@ -50,6 +55,11 @@ const TranscriptionBlock = ({ onWordClick, transcription }: Props) => {
               onClick={() => {
                 onWordClick(index);
               }}
+              style={
+                index === nowPlayingWordIndex
+                  ? { background: `${colors.yellow[500]}80` }
+                  : {}
+              }
             >
               {word.word}
             </Word>

--- a/src/renderer/components/TranscriptionBlock.tsx
+++ b/src/renderer/components/TranscriptionBlock.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 import { Box } from '@mui/material';
-import { useEffect, useState } from 'react';
 import { Transcription } from 'sharedTypes';
 import colors from '../colors';
 
@@ -31,27 +30,15 @@ const Word = styled('span')`
 
 interface Props {
   transcription: Transcription;
-  time: number;
+  nowPlayingWordIndex: number | null;
   onWordClick: (wordIndex: number) => void;
 }
 
-const TranscriptionBlock = ({ onWordClick, transcription, time }: Props) => {
-  const [nowPlayingWordIndex, setNowPlayingWordIndex] = useState<number | null>(
-    null
-  );
-
-  useEffect(() => {
-    const newPlayingWordIndex = transcription.words.findIndex(
-      (word) =>
-        time >= word.outputStartTime &&
-        time <= word.outputStartTime + word.duration &&
-        !word.deleted
-    );
-    if (newPlayingWordIndex !== nowPlayingWordIndex)
-      setNowPlayingWordIndex(newPlayingWordIndex);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [time, transcription]);
-
+const TranscriptionBlock = ({
+  onWordClick,
+  transcription,
+  nowPlayingWordIndex,
+}: Props) => {
   return (
     <TranscriptionBox>
       <p

--- a/src/renderer/pages/Project.tsx
+++ b/src/renderer/pages/Project.tsx
@@ -29,6 +29,9 @@ const ProjectPage = () => {
   // UI states
   const [time, setTime] = useState<number>(0);
   const [isPlaying, setIsPlaying] = useState(false);
+  const [nowPlayingWordIndex, setNowPlayingWordIndex] = useState<number | null>(
+    null
+  );
 
   const videoPreviewControllerRef = useRef<VideoPreviewControllerRef>(null);
 
@@ -78,6 +81,21 @@ const ProjectPage = () => {
     };
   });
 
+  useEffect(() => {
+    if (currentProject !== null && currentProject?.transcription !== null) {
+      const { words } = currentProject.transcription;
+      const newPlayingWordIndex = words.findIndex(
+        (word) =>
+          time >= word.outputStartTime &&
+          time <= word.outputStartTime + word.duration &&
+          !word.deleted
+      );
+      if (newPlayingWordIndex !== nowPlayingWordIndex)
+        setNowPlayingWordIndex(newPlayingWordIndex);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [time, currentProject?.transcription]);
+
   const onWordClick: (wordIndex: number) => void = (wordIndex) => {
     if (currentProject !== null && currentProject?.transcription !== null) {
       const newTime =
@@ -110,7 +128,7 @@ const ProjectPage = () => {
           {currentProject?.transcription && (
             <TranscriptionBlock
               transcription={currentProject.transcription}
-              time={time}
+              nowPlayingWordIndex={nowPlayingWordIndex}
               onWordClick={onWordClick}
             />
           )}

--- a/src/renderer/pages/Project.tsx
+++ b/src/renderer/pages/Project.tsx
@@ -82,16 +82,16 @@ const ProjectPage = () => {
   });
 
   useEffect(() => {
-    if (currentProject?.transcription != null) {
+    if (currentProject !== null && currentProject?.transcription !== null) {
       const { words } = currentProject.transcription;
-      const currentPlayingWordIndex = words.findIndex(
+      const newPlayingWordIndex = words.findIndex(
         (word) =>
           time >= word.outputStartTime &&
           time <= word.outputStartTime + word.duration &&
           !word.deleted
       );
-      if (currentPlayingWordIndex !== nowPlayingWordIndex)
-        setNowPlayingWordIndex(currentPlayingWordIndex);
+      if (newPlayingWordIndex !== nowPlayingWordIndex)
+        setNowPlayingWordIndex(newPlayingWordIndex);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [time, currentProject?.transcription]);

--- a/src/renderer/pages/Project.tsx
+++ b/src/renderer/pages/Project.tsx
@@ -87,7 +87,8 @@ const ProjectPage = () => {
       const currentPlayingWordIndex = words.findIndex(
         (word) =>
           time >= word.outputStartTime &&
-          time <= word.outputStartTime + word.duration
+          time <= word.outputStartTime + word.duration &&
+          !word.deleted
       );
       if (currentPlayingWordIndex !== nowPlayingWordIndex)
         setNowPlayingWordIndex(currentPlayingWordIndex);
@@ -95,10 +96,8 @@ const ProjectPage = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [time, currentProject?.transcription]);
 
-  // TODO: figure out return type
   const onWordClick: (wordIndex: number) => void = (wordIndex) => {
     if (currentProject !== null && currentProject?.transcription !== null) {
-      // return currentProject.transcription?.words[wordIndex];
       const newTime =
         currentProject.transcription.words[wordIndex].outputStartTime;
       setPlaybackTime(newTime);
@@ -129,6 +128,7 @@ const ProjectPage = () => {
           {currentProject?.transcription && (
             <TranscriptionBlock
               transcription={currentProject.transcription}
+              nowPlayingWordIndex={nowPlayingWordIndex}
               onWordClick={onWordClick}
             />
           )}

--- a/src/renderer/pages/Project.tsx
+++ b/src/renderer/pages/Project.tsx
@@ -29,6 +29,9 @@ const ProjectPage = () => {
   // UI states
   const [time, setTime] = useState<number>(0);
   const [isPlaying, setIsPlaying] = useState(false);
+  const [nowPlayingWordIndex, setNowPlayingWordIndex] = useState<number | null>(
+    null
+  );
 
   const videoPreviewControllerRef = useRef<VideoPreviewControllerRef>(null);
 
@@ -78,6 +81,20 @@ const ProjectPage = () => {
     };
   });
 
+  useEffect(() => {
+    if (currentProject?.transcription != null) {
+      const { words } = currentProject.transcription;
+      const currentPlayingWordIndex = words.findIndex(
+        (word) =>
+          time >= word.outputStartTime &&
+          time <= word.outputStartTime + word.duration
+      );
+      if (currentPlayingWordIndex !== nowPlayingWordIndex)
+        setNowPlayingWordIndex(currentPlayingWordIndex);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [time, currentProject?.transcription]);
+
   // TODO: figure out return type
   const onWordClick: (wordIndex: number) => void = (wordIndex) => {
     if (currentProject !== null && currentProject?.transcription !== null) {
@@ -126,6 +143,7 @@ const ProjectPage = () => {
               setIsPlaying={setIsPlaying}
               ref={videoPreviewControllerRef}
             />
+            <p>{nowPlayingWordIndex}</p>
           </Box>
         </Stack>
         {isExporting && (

--- a/src/renderer/pages/Project.tsx
+++ b/src/renderer/pages/Project.tsx
@@ -29,9 +29,6 @@ const ProjectPage = () => {
   // UI states
   const [time, setTime] = useState<number>(0);
   const [isPlaying, setIsPlaying] = useState(false);
-  const [nowPlayingWordIndex, setNowPlayingWordIndex] = useState<number | null>(
-    null
-  );
 
   const videoPreviewControllerRef = useRef<VideoPreviewControllerRef>(null);
 
@@ -81,21 +78,6 @@ const ProjectPage = () => {
     };
   });
 
-  useEffect(() => {
-    if (currentProject !== null && currentProject?.transcription !== null) {
-      const { words } = currentProject.transcription;
-      const newPlayingWordIndex = words.findIndex(
-        (word) =>
-          time >= word.outputStartTime &&
-          time <= word.outputStartTime + word.duration &&
-          !word.deleted
-      );
-      if (newPlayingWordIndex !== nowPlayingWordIndex)
-        setNowPlayingWordIndex(newPlayingWordIndex);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [time, currentProject?.transcription]);
-
   const onWordClick: (wordIndex: number) => void = (wordIndex) => {
     if (currentProject !== null && currentProject?.transcription !== null) {
       const newTime =
@@ -128,7 +110,7 @@ const ProjectPage = () => {
           {currentProject?.transcription && (
             <TranscriptionBlock
               transcription={currentProject.transcription}
-              nowPlayingWordIndex={nowPlayingWordIndex}
+              time={time}
               onWordClick={onWordClick}
             />
           )}

--- a/src/renderer/pages/Project.tsx
+++ b/src/renderer/pages/Project.tsx
@@ -29,9 +29,7 @@ const ProjectPage = () => {
   // UI states
   const [time, setTime] = useState<number>(0);
   const [isPlaying, setIsPlaying] = useState(false);
-  const [nowPlayingWordIndex, setNowPlayingWordIndex] = useState<number | null>(
-    null
-  );
+  const [nowPlayingWordIndex, setNowPlayingWordIndex] = useState<number>(0);
 
   const videoPreviewControllerRef = useRef<VideoPreviewControllerRef>(null);
 

--- a/src/renderer/pages/Project.tsx
+++ b/src/renderer/pages/Project.tsx
@@ -143,7 +143,6 @@ const ProjectPage = () => {
               setIsPlaying={setIsPlaying}
               ref={videoPreviewControllerRef}
             />
-            <p>{nowPlayingWordIndex}</p>
           </Box>
         </Stack>
         {isExporting && (

--- a/src/renderer/pages/Project.tsx
+++ b/src/renderer/pages/Project.tsx
@@ -83,8 +83,7 @@ const ProjectPage = () => {
 
   useEffect(() => {
     if (currentProject !== null && currentProject?.transcription !== null) {
-      const { words } = currentProject.transcription;
-      const newPlayingWordIndex = words.findIndex(
+      const newPlayingWordIndex = currentProject.transcription.words.findIndex(
         (word) =>
           time >= word.outputStartTime &&
           time <= word.outputStartTime + word.duration &&

--- a/src/renderer/pages/Project.tsx
+++ b/src/renderer/pages/Project.tsx
@@ -156,6 +156,7 @@ const ProjectPage = () => {
     };
   });
 
+  // TODO: Look into optimisations
   useEffect(() => {
     if (currentProject !== null && currentProject?.transcription !== null) {
       const newPlayingWordIndex = currentProject.transcription.words.findIndex(

--- a/src/renderer/store/transcription/reducer.ts
+++ b/src/renderer/store/transcription/reducer.ts
@@ -59,7 +59,6 @@ const transcriptionReducer: Reducer<Transcription | null, Action<any>> = (
     pasteyWords = pasteyWords?.map((word) => ({ ...word, deleted: false })); // Undeleting the cut words
     const suffix = transcription?.words.slice(toIndex);
 
-    // Have to check this if to get rid of linter error
     if (pasteyWords !== undefined && suffix !== undefined) {
       const updatedTranscription = {
         ...transcription,

--- a/src/renderer/store/transcription/reducer.ts
+++ b/src/renderer/store/transcription/reducer.ts
@@ -61,10 +61,11 @@ const transcriptionReducer: Reducer<Transcription | null, Action<any>> = (
 
     // Have to check this if to get rid of linter error
     if (pasteyWords !== undefined && suffix !== undefined) {
-      return {
+      const updatedTranscription = {
         ...transcription,
         words: prefix?.concat(pasteyWords, suffix), // Concatonating the sub arrays
       };
+      return processTranscript(updatedTranscription);
     }
   }
 
@@ -79,10 +80,11 @@ const transcriptionReducer: Reducer<Transcription | null, Action<any>> = (
 
     // Have to check this if to get rid of linter error
     if (suffix !== undefined) {
-      return {
+      const updatedTranscription = {
         ...transcription,
         words: prefix?.concat(suffix), // Concatonating the sub arrays
       };
+      return processTranscript(updatedTranscription);
     }
   }
 

--- a/src/renderer/store/transcription/reducer.ts
+++ b/src/renderer/store/transcription/reducer.ts
@@ -55,14 +55,14 @@ const transcriptionReducer: Reducer<Transcription | null, Action<any>> = (
 
     // Getting the subarrays for the new transcription
     const prefix = transcription?.words.slice(0, toIndex);
-    let pasteyWords = transcription?.words.slice(startIndex, endIndex + 1); // Words to be pasted
-    pasteyWords = pasteyWords?.map((word) => ({ ...word, deleted: false })); // Undeleting the cut words
+    let pastedWords = transcription?.words.slice(startIndex, endIndex + 1); // Words to be pasted
+    pastedWords = pastedWords?.map((word) => ({ ...word, deleted: false })); // Undeleting the cut words
     const suffix = transcription?.words.slice(toIndex);
 
-    if (pasteyWords !== undefined && suffix !== undefined) {
+    if (pastedWords !== undefined && suffix !== undefined) {
       const updatedTranscription = {
         ...transcription,
-        words: prefix?.concat(pasteyWords, suffix), // Concatonating the sub arrays
+        words: prefix?.concat(pastedWords, suffix), // Concatonating the sub arrays
       };
       return processTranscript(updatedTranscription);
     }


### PR DESCRIPTION
<!-- Notes!
    Please do not forget to:
        1. assign some one to review your pull request!
        2. did you include unit tests?
        3. did you merge develop into your branch?
        4. notify the #pr channel on slack!

    Feel free to remove the sections which you do not fill out
 -->

## Summary

Highlights the word in the transcription that is currently playing. 

Please note, I do intended to animate the transition between words, however wanted to get this feature done for the MVP. For now the switch from one word to another feels a little janky. I plan to improve this by having the highlight slide over to the next word. 

I also had to make a tiny change to the PASTE_WORD and UNDO_PASTE_WORD ops to ensure the output start word time was updated - otherwise it caused some super weird behavior with the highlighting. 

<hr/>

### Why is this change needed?

This is feature helps the editor easily identify the word that's currently playing and enables them to follow along the transcript as the video is playing. 

The feature was ✨ _inspired_ ✨by an unnamed competitor. 

<hr/>

### What did you change?

Added a use effect hook that's dependent on the playback time. This will find the word thats currently playing and store its index in nowPlayingWordIndex. This is passed to the transcription block which will set the background color of the now playing word to orange 500 with a 50% opacity (same as the on hover color)

Also modified PASTE_WORD and UNDO_PASTE_WORD ops to return the processed transcription to ensure the new output start time was updated in store. 

<hr/>

### Does it depend on any other changes/PRs?

Nope.

<hr/>

### Screenshots of UI changes, if any


https://user-images.githubusercontent.com/27614346/169824053-713757a6-62cd-4bbc-b71a-dab4700a7480.mov



<hr/>


### Any sections in particular you want reviewed/discussed

I had refactored this and moved the logic into the transcription block itself, however moved it back into the project page because having it in the transcription block means I need to pass `time` in as a prop. This would mean the transcription block would re-render every time the `time` value changes (which is a lot...) so I reverted the change. 

I'm not that experienced with react, so someone who is, please advise on the best approach.  

<hr/>

### OS

<!-- To select your OS. Place an 'x' within [ ]. eg. - [x] Linux -->

- [ ] Linux
- [x] MacOS
- [ ] Windows
