### PR TITLE
Make the play button restart the video if at the end

### DIFF
--- a/src/renderer/components/VideoPreview/VideoPreviewController.tsx
+++ b/src/renderer/components/VideoPreview/VideoPreviewController.tsx
@@ -142,17 +142,6 @@ const VideoPreviewControllerBase = (
     clockRef.current.isRunning = true;
   };
 
-  // Starts video, timer & UI
-  const play = () => {
-    if (!clockRef.current.isRunning) {
-      if (clockRef.current.time < outputVideoLength.current) {
-        videoPreviewRef?.current?.play();
-        startTimer();
-        setIsPlaying(true);
-      }
-    }
-  };
-
   // Sets the video, timer & UI playback time
   const setPlaybackTime = (time: number) => {
     const { isRunning } = clockRef.current;
@@ -180,6 +169,20 @@ const VideoPreviewControllerBase = (
       }
     } else {
       pause();
+    }
+  };
+
+  // Starts video, timer & UI
+  const play = () => {
+    if (!clockRef.current.isRunning) {
+      // If we're at the end of the video, restart it
+      if (clockRef.current.time >= outputVideoLength.current) {
+        setPlaybackTime(0);
+      }
+
+      startTimer();
+      videoPreviewRef?.current?.play();
+      setIsPlaying(true);
     }
   };
 


### PR DESCRIPTION
- Calls setPlaybackTime if at the end of the video, to restart it
- Play function is moved after setPlaybackTime so that it only references the function after it is defined

Video:

https://user-images.githubusercontent.com/6735055/181699971-bfdbe2f8-54c8-49c9-b68b-c8095a8c20ef.mov

Resolves #94 