### PR TITLE
Bugfix/drag and drop accepts any file type

### DIFF
--- a/src/renderer/components/SelectMediaBlock.tsx
+++ b/src/renderer/components/SelectMediaBlock.tsx
@@ -90,14 +90,19 @@ const SelectMediaBlock = ({
 
     if (draggedFiles.length > 0) {
       /* Currently only supporting single file import - taking first file */
-      const fileType = draggedFiles[0].type.split('/')[1];
-      if (getMediaType(fileType) !== null) {
-        const fileName = draggedFiles[0].name;
-        const filePath = draggedFiles[0].path;
+      const fileType = draggedFiles[0].type.split('/')[0];
+      console.log(fileType);
+      const fileTypeExtension = draggedFiles[0].type.split('/')[1];
+      console.log(fileTypeExtension);
+      if (fileType !== null && (fileType === 'audio' || fileType === 'video')) {
+        if (getMediaType(fileTypeExtension) !== null) {
+          const fileName = draggedFiles[0].name;
+          const filePath = draggedFiles[0].path;
 
-        setMediaFilePath(filePath);
-        setMediaFileName(fileName);
-        setIsAwaitingMedia(false);
+          setMediaFilePath(filePath);
+          setMediaFileName(fileName);
+          setIsAwaitingMedia(false);
+        }
       }
     }
   };

--- a/src/renderer/components/SelectMediaBlock.tsx
+++ b/src/renderer/components/SelectMediaBlock.tsx
@@ -133,7 +133,7 @@ const SelectMediaBlock = ({
             sx={{ height: '150px' }}
           >
             <Typography variant="p-300">Drag and drop</Typography>
-            <Typography variant="p-300">Mp4 or Mp3 file here</Typography>
+            <Typography variant="p-300">MP4 or MP3 file here</Typography>
             <Typography variant="p-300">or</Typography>
             <Button color="primary" onClick={selectMedia}>
               Browse

--- a/src/renderer/components/SelectMediaBlock.tsx
+++ b/src/renderer/components/SelectMediaBlock.tsx
@@ -1,4 +1,3 @@
-import { useTabsList } from '@mui/base';
 import { Box, styled, Typography, Stack, Button } from '@mui/material';
 import { Dispatch, SetStateAction, useState } from 'react';
 import { getMediaType } from '../util';

--- a/src/renderer/components/SelectMediaBlock.tsx
+++ b/src/renderer/components/SelectMediaBlock.tsx
@@ -1,5 +1,7 @@
+import { useTabsList } from '@mui/base';
 import { Box, styled, Typography, Stack, Button } from '@mui/material';
 import { Dispatch, SetStateAction, useState } from 'react';
+import { getMediaType } from '../util';
 import colors from '../colors';
 import ipc from '../ipc';
 
@@ -84,19 +86,20 @@ const SelectMediaBlock = ({
   const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
     e.stopPropagation();
     e.preventDefault();
-
     exitDragZone();
-
     const draggedFiles = e.dataTransfer.files;
 
     if (draggedFiles.length > 0) {
       /* Currently only supporting single file import - taking first file */
-      const fileName = draggedFiles[0].name;
-      const filePath = draggedFiles[0].path;
+      const fileType = draggedFiles[0].type.split('/')[1];
+      if (getMediaType(fileType) !== null) {
+        const fileName = draggedFiles[0].name;
+        const filePath = draggedFiles[0].path;
 
-      setMediaFilePath(filePath);
-      setMediaFileName(fileName);
-      setIsAwaitingMedia(false);
+        setMediaFilePath(filePath);
+        setMediaFileName(fileName);
+        setIsAwaitingMedia(false);
+      }
     }
   };
 
@@ -130,7 +133,8 @@ const SelectMediaBlock = ({
             justifyContent="space-between"
             sx={{ height: '150px' }}
           >
-            <Typography variant="p-300">Drag and drop file here</Typography>
+            <Typography variant="p-300">Drag and drop</Typography>
+            <Typography variant="p-300">Mp4 or Mp3 file here</Typography>
             <Typography variant="p-300">or</Typography>
             <Button color="primary" onClick={selectMedia}>
               Browse

--- a/src/renderer/util.ts
+++ b/src/renderer/util.ts
@@ -24,7 +24,7 @@ export const extractFileExtension: (filePath: string) => string | null = (
 export const getMediaType: (extension: string) => 'audio' | 'video' | null = (
   extension
 ) => {
-  const audioFileExtensions = ['mp3'];
+  const audioFileExtensions = ['mp3', 'mpeg'];
   const videoFileExtensions = ['mp4'];
 
   if (audioFileExtensions.includes(extension)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3756,7 +3756,7 @@ ejs@^3.1.7:
   dependencies:
     jake "^10.8.5"
 
-electron-builder@23.3.3:
+electron-builder@^23.3.3:
   version "23.3.3"
   resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-23.3.3.tgz#88d4e584a99b9e36ca4e8432b1163a1ef877355f"
   integrity sha512-mFYYdhoFPKevP6y5uaaF3dusmB2OtQ/HnwwpyOePeU7QDS0SEIAUokQsHUanAiJAZcBqtY7iyLBgX18QybdFFw==


### PR DESCRIPTION

## Summary

<!-- Provide a summary of what your changes achieve aka what the goal of the PR is -->

<hr/>

### Why is this change needed?
 Constraints were present when importing via dialog, but not through the drag feature. 
<hr/>

### What did you change?
Branch adds in drag and drop feature only accedting the file types specified in the getMediaType function in utils. 
<hr/>

### Explain things which the reviewers are likely to need explaining. Remember that they didn’t write the code.
Electron 18/ chrome update doesnt allow files to be detected when file is still currently being dragged. So had to add constraint after the file has been dropped.  (https://stackoverflow.com/questions/11065803/determine-what-is-being-dragged-from-dragenter-dragover-events)
<hr/>



<hr/>

### OS

<!-- To select your OS. Place an 'x' within [ ]. eg. - [x] Linux -->

- [ ] Linux
- [ ] MacOS
- [x] Windows
