### PR TITLE
bugfix/Move onClick method from child to parent button

### DIFF
--- a/src/renderer/components/MediaDisplayOnImport.tsx
+++ b/src/renderer/components/MediaDisplayOnImport.tsx
@@ -34,8 +34,9 @@ const MediaDisplayOnImport = ({ fileName, removeMediaFromImport }: Props) => {
         </Stack>
         <IconButton
           sx={{ color: colors.yellow[500], fontSize: 24, margin: '5px' }}
+          onClick={removeMediaFromImport}
         >
-          <DeleteIcon onClick={removeMediaFromImport} />
+          <DeleteIcon />
         </IconButton>
       </Stack>
     </CustomBox>


### PR DESCRIPTION
Only a one line change. 

There was a button where the onClick method was on the icon and not the parent button which was causing an error in the console. The onClick has been moved into the button component and the warning is gone. 