### PR TITLE
project name stays in text field when you go back

### DIFF
--- a/src/renderer/components/NewProjectModal/ModalContainer.tsx
+++ b/src/renderer/components/NewProjectModal/ModalContainer.tsx
@@ -28,6 +28,7 @@ interface Props {
 
 const ModalContainer = ({ isOpen, closeModal }: Props) => {
   const [currentView, setCurrentView] = useState<number>(0);
+  const [projectName, setProjectName] = useState<string>('');
 
   const dispatch = useDispatch();
 
@@ -70,7 +71,12 @@ const ModalContainer = ({ isOpen, closeModal }: Props) => {
     switch (viewComponent) {
       case NewProjectView:
         return (
-          <NewProjectView closeModal={handleModalClose} nextView={nextView} />
+          <NewProjectView
+            closeModal={handleModalClose}
+            nextView={nextView}
+            projectName={projectName}
+            setProjectName={setProjectName}
+          />
         );
       case ImportMediaView:
         return (

--- a/src/renderer/components/NewProjectModal/NewProjectView.tsx
+++ b/src/renderer/components/NewProjectModal/NewProjectView.tsx
@@ -12,6 +12,8 @@ import { PrimaryButton, SecondaryButton } from '../Blocks/Buttons';
 interface Props {
   closeModal: () => void;
   nextView: () => void;
+  projectName: string;
+  setProjectName: (projectName: string) => void;
 }
 
 const CustomStack = styled(Stack)({
@@ -36,8 +38,12 @@ const Container = styled(Box)({
   height: '200px',
 });
 
-const NewProjectView = ({ closeModal, nextView }: Props) => {
-  const [projectName, setProjectName] = useState<string>('');
+const NewProjectView = ({
+  closeModal,
+  nextView,
+  projectName,
+  setProjectName,
+}: Props) => {
   const [isAwaitingProjectName, setIsAwaitingProjectName] =
     useState<boolean>(true);
 

--- a/src/renderer/components/NewProjectModal/NewProjectView.tsx
+++ b/src/renderer/components/NewProjectModal/NewProjectView.tsx
@@ -1,7 +1,7 @@
 import { styled, Stack, Box, TextField, Typography } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import IconButton from '@mui/material/IconButton';
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent } from 'react';
 import { useDispatch } from 'react-redux';
 import { makeProjectWithoutMedia } from '../../util';
 import { projectCreated } from '../../store/currentProject/actions';
@@ -44,9 +44,6 @@ const NewProjectView = ({
   projectName,
   setProjectName,
 }: Props) => {
-  const [isAwaitingProjectName, setIsAwaitingProjectName] =
-    useState<boolean>(true);
-
   const dispatch = useDispatch();
 
   const setProjectInStore = async (project: RuntimeProject) => {
@@ -66,17 +63,12 @@ const NewProjectView = ({
     event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => {
     setProjectName(event.target.value);
-    if (event.target.value !== '') {
-      setIsAwaitingProjectName(false);
-    } else {
-      setIsAwaitingProjectName(true);
-    }
   };
 
   const continueButton = (
     <PrimaryButton
       onClick={handleContinue}
-      disabled={isAwaitingProjectName}
+      disabled={!projectName.trim()}
       fullWidth
     >
       Continue


### PR DESCRIPTION
Elevated the state so that the project name can remain filled when the user continues to the next modal then navigates back to the new project view


## Summary

Lifted the project name state from the new project view into the modal container so that the project name persists when you continue to the import media view then navigate back again.

<hr/>

Currently the project name clears when the user navigates back to the project name view, which would be annoying if they only wanted to fix a simple typo.

<hr/>


### OS

<!-- To select your OS. Place an 'x' within [ ]. eg. - [x] Linux -->

- [x] Linux
- [x] MacOS
- [x] Windows
