### PR TITLE
Support dragging to select words

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -2,4 +2,4 @@
 
 // Whether to use the sample transcription instead of actually transcribing.
 // Useful for testing.
-export const USE_DUMMY = false;
+export const USE_DUMMY = true;

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -2,4 +2,4 @@
 
 // Whether to use the sample transcription instead of actually transcribing.
 // Useful for testing.
-export const USE_DUMMY = true;
+export const USE_DUMMY = false;

--- a/src/renderer/components/TranscriptionBlock.tsx
+++ b/src/renderer/components/TranscriptionBlock.tsx
@@ -50,8 +50,15 @@ const TranscriptionBlock = ({
 
   const dispatch = useDispatch();
 
-  const clearSelection: () => void = () => {
-    dispatch(selectionCleared());
+  const clearSelection: (
+    dragSelectAnchor: number | null,
+    clearAnchor: () => void
+  ) => void = (dragSelectAnchor, clearAnchor) => {
+    if (dragSelectAnchor == null) {
+      dispatch(selectionCleared());
+    } else {
+      clearAnchor();
+    }
   };
 
   const space: (key: string, isDropMarkerActive: boolean) => JSX.Element = (
@@ -72,15 +79,22 @@ const TranscriptionBlock = ({
 
   const renderTranscription: RenderTranscription = (
     onWordMouseDown,
+    onWordMouseMove,
     dragState,
     isWordBeingDragged,
     mouse,
     mouseThrottled,
     dropBeforeIndex,
     setDropBeforeIndex,
-    cancelDrag
+    cancelDrag,
+    dragSelectAnchor,
+    setDragSelectAnchor
   ) => (
-    <TranscriptionBox onClick={clearSelection}>
+    <TranscriptionBox
+      onMouseUp={() =>
+        clearSelection(dragSelectAnchor, () => setDragSelectAnchor(null))
+      }
+    >
       {transcription.words.map((word, index) =>
         word.deleted ? null : (
           <Fragment key={`${word.originalIndex}-${word.pasteKey}`}>
@@ -96,6 +110,7 @@ const TranscriptionBlock = ({
               text={word.word}
               index={index}
               onMouseDown={onWordMouseDown(index)}
+              onMouseMove={() => onWordMouseMove(index)}
               dragState={dragState}
               isBeingDragged={isWordBeingDragged(index)}
               mouse={isWordBeingDragged(index) ? mouse : mouseThrottled}

--- a/src/renderer/components/TranscriptionBlock.tsx
+++ b/src/renderer/components/TranscriptionBlock.tsx
@@ -61,21 +61,23 @@ const TranscriptionBlock = ({
     }
   };
 
-  const space: (key: string, isDropMarkerActive: boolean) => JSX.Element = (
-    key,
-    isDropMarkerActive
-  ) => (
-    <span
-      key={key}
-      style={{
-        background: isDropMarkerActive ? 'white' : 'none',
-        transition: 'background 0.2s',
-        width: '2px',
-        paddingLeft: '1px',
-        paddingRight: '1px',
-      }}
-    />
-  );
+  const space: (key: string, isDropMarkerActive: boolean) => JSX.Element =
+    useMemo(
+      () => (key, isDropMarkerActive) =>
+        (
+          <span
+            key={key}
+            style={{
+              background: isDropMarkerActive ? 'white' : 'none',
+              transition: 'background 0.2s',
+              width: '2px',
+              paddingLeft: '1px',
+              paddingRight: '1px',
+            }}
+          />
+        ),
+      []
+    );
 
   const renderTranscription: RenderTranscription = (
     onWordMouseDown,

--- a/src/renderer/components/Word.tsx
+++ b/src/renderer/components/Word.tsx
@@ -36,6 +36,7 @@ interface Props {
   onMouseDown: (
     wordRef: RefObject<HTMLDivElement>
   ) => MouseEventHandler<HTMLDivElement>;
+  onMouseMove: () => void;
   dragState: DragState; // current state of ANY drag (null if no word being dragged)
   isBeingDragged: boolean; // whether THIS word is currently being dragged
   mouse: MousePosition;
@@ -52,6 +53,7 @@ const Word = ({
   isSelected,
   text,
   onMouseDown,
+  onMouseMove,
   dragState,
   isBeingDragged,
   mouse,
@@ -182,6 +184,7 @@ const Word = ({
       ref={ref}
       onClick={onClick}
       onMouseDown={onMouseDown(ref)}
+      onMouseMove={onMouseMove}
       style={{ ...style, position: isBeingDragged ? 'fixed' : 'relative' }}
     >
       {text}

--- a/src/renderer/components/WordDragManager.tsx
+++ b/src/renderer/components/WordDragManager.tsx
@@ -14,11 +14,12 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Point } from 'electron';
 import { useThrottle } from '@react-hook/throttle';
 import { IndexRange } from 'sharedTypes';
+import { useDebounceCallback } from '@react-hook/debounce';
 import { dispatchOp } from '../store/undoStack/opHelpers';
 import { makeMoveWords } from '../store/undoStack/ops';
 import {
   selectionCleared,
-  selectionRangeAdded,
+  selectionRangeSetTo,
 } from '../store/selection/actions';
 import { ApplicationStore } from '../store/sharedHelpers';
 import { MouseButton, rangeLengthOne } from '../util';
@@ -136,11 +137,12 @@ const WordDragManager = ({ renderTranscription, containerRef }: Props) => {
         endIndex: Math.max(wordIndex, dragSelectAnchor) + 1,
       };
 
-      dispatch(selectionCleared());
-      dispatch(selectionRangeAdded(range));
+      dispatch(selectionRangeSetTo(range));
     },
     [dragSelectAnchor, dispatch]
   );
+
+  const onWordMouseMoveDebounced = useDebounceCallback(onWordMouseMove, 10);
 
   // Helper to determine whether a given word is being dragged
   const isWordBeingDragged: (wordIndex: number) => boolean = useMemo(
@@ -183,7 +185,7 @@ const WordDragManager = ({ renderTranscription, containerRef }: Props) => {
     <div onMouseUp={onMouseUp}>
       {renderTranscription(
         onWordMouseDown,
-        onWordMouseMove,
+        onWordMouseMoveDebounced,
         dragState,
         isWordBeingDragged,
         mouse,

--- a/src/renderer/store/selection/actions.ts
+++ b/src/renderer/store/selection/actions.ts
@@ -46,7 +46,7 @@ export const selectionRangeToggled: (
 };
 
 /**
- * Sets the range to be a certain value, minimally modifying the existing range for efficiency.
+ * Efficiently sets the range to be a certain value.
  */
 export const selectionRangeSetTo: (
   indexRange: IndexRange

--- a/src/renderer/store/selection/actions.ts
+++ b/src/renderer/store/selection/actions.ts
@@ -4,6 +4,7 @@ import { Action } from '../action';
 export const SELECTION_RANGE_ADDED = 'SELECTION_RANGE_ADDED';
 export const SELECTION_RANGE_REMOVED = 'SELECTION_RANGE_REMOVED';
 export const SELECTION_RANGE_TOGGLED = 'SELECTION_RANGE_TOGGLED';
+export const SELECTION_RANGE_SET_TO = 'SELECTION_RANGE_SET_TO';
 export const SELECTION_CLEARED = 'SELECTION_CLEARED';
 
 /**
@@ -40,6 +41,18 @@ export const selectionRangeToggled: (
 ) => Action<IndexRange> = (indexRange) => {
   return {
     type: SELECTION_RANGE_TOGGLED,
+    payload: indexRange,
+  };
+};
+
+/**
+ * Sets the range to be a certain value, minimally modifying the existing range for efficiency.
+ */
+export const selectionRangeSetTo: (
+  indexRange: IndexRange
+) => Action<IndexRange> = (indexRange) => {
+  return {
+    type: SELECTION_RANGE_SET_TO,
     payload: indexRange,
   };
 };

--- a/src/renderer/store/selection/reducer.ts
+++ b/src/renderer/store/selection/reducer.ts
@@ -1,10 +1,12 @@
 import { Reducer } from 'redux';
+import { rangeToIndices } from 'renderer/util';
 import { IndexRange } from '../../../sharedTypes';
 import {
   SELECTION_RANGE_ADDED,
   SELECTION_RANGE_REMOVED,
   SELECTION_CLEARED,
   SELECTION_RANGE_TOGGLED,
+  SELECTION_RANGE_SET_TO,
 } from './actions';
 import { ApplicationStore, initialStore } from '../sharedHelpers';
 import { Action } from '../action';
@@ -59,6 +61,13 @@ const selectionReducer: Reducer<ApplicationStore['selection'], Action<any>> = (
     }
 
     return Array.from(selectionSet);
+  }
+
+  if (action.type === SELECTION_RANGE_SET_TO) {
+    const range = action.payload as IndexRange;
+
+    // Build the selection from scratch out of the single range that was given
+    return rangeToIndices(range);
   }
 
   if (action.type === SELECTION_CLEARED) {

--- a/src/renderer/util.ts
+++ b/src/renderer/util.ts
@@ -210,6 +210,21 @@ export const rangesToIndices: (ranges: IndexRange[]) => Set<number> = (
   return indicesSet;
 };
 
+/**
+ * Similar to rangesToIndices, but for a single range - also returns as a list and
+ * maintains numerical order.
+ * @param range
+ */
+export const rangeToIndices: (range: IndexRange) => number[] = (range) => {
+  const indices: number[] = [];
+
+  for (let index = range.startIndex; index < range.endIndex; index += 1) {
+    indices.push(index);
+  }
+
+  return indices;
+};
+
 export interface Point {
   x: number;
   y: number;
@@ -248,3 +263,14 @@ export const rangeLengthOne: (index: number) => IndexRange = (index) => ({
   startIndex: index,
   endIndex: index + 1,
 });
+
+/**
+ * Dev helper for measuring and printing time taken by a function
+ */
+export function measureTimeTaken<T extends (...args: any) => any>(func: T) {
+  const before = performance.now();
+  const returnValue: ReturnType<T> = func();
+  const after = performance.now();
+  console.log(after - before);
+  return returnValue;
+}


### PR DESCRIPTION
Depends on #168 

Demo:

https://user-images.githubusercontent.com/6735055/184303355-b85b874a-6b19-4c60-ad6f-27d4e41482a5.mov

Generally performant below a few hundred words, once you start copying a lot and end up with 500+ words it gets a bit slow (though the whole app is not really optimised for this in general right now). I tried profiling to get some quick wins but to be honest it's more of a death by a thousand cuts situation (e.g. each render of a word might only take 0.1ms but when there are 500 of them we slow down to 20fps). There are a number of solutions to this but none are particularly trivial so I'd say leave it for now