### PR TITLE
Refactor saveChangesDialog to stop codegen from breaking

### DIFF
--- a/src/main/handlers/file/saveChangesDialog.ts
+++ b/src/main/handlers/file/saveChangesDialog.ts
@@ -1,20 +1,12 @@
 import { BrowserWindow, dialog } from 'electron';
+import { SaveDialogSelections } from '../helpers/saveDialog';
 
 type SaveChangesDialog = (
   mainWindow: BrowserWindow,
   projectFileName?: string
 ) => SaveDialogSelections;
 
-export enum SaveDialogSelections {
-  SAVE_SELECTED = 0,
-  DONT_SAVE_SELECTED = 1,
-  SAVE_CANCELLED = 2,
-}
-
-export const saveChangesDialog: SaveChangesDialog = (
-  mainWindow,
-  projectFileName
-) => {
+const saveChangesDialog: SaveChangesDialog = (mainWindow, projectFileName) => {
   const result = dialog.showMessageBoxSync(mainWindow, {
     message: projectFileName
       ? `Do you want to save the changes you have made to ${projectFileName}?`
@@ -27,3 +19,5 @@ export const saveChangesDialog: SaveChangesDialog = (
 
   return result;
 };
+
+export default saveChangesDialog;

--- a/src/main/handlers/helpers/saveDialog.ts
+++ b/src/main/handlers/helpers/saveDialog.ts
@@ -1,0 +1,7 @@
+/* eslint-disable import/prefer-default-export */
+
+export enum SaveDialogSelections {
+  SAVE_SELECTED = 0,
+  DONT_SAVE_SELECTED = 1,
+  SAVE_CANCELLED = 2,
+}

--- a/src/main/handlers/helpers/saveUtils.ts
+++ b/src/main/handlers/helpers/saveUtils.ts
@@ -1,10 +1,8 @@
 import { BrowserWindow, dialog } from 'electron';
 import { writeFile } from 'fs/promises';
-import {
-  saveChangesDialog,
-  SaveDialogSelections,
-} from '../file/saveChangesDialog';
+import saveChangesDialog from '../file/saveChangesDialog';
 import { PersistedProject, RuntimeProject } from '../../../sharedTypes';
+import { SaveDialogSelections } from './saveDialog';
 
 export const getSaveFilePath: (
   mainWindow: BrowserWindow | null,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -12,6 +12,7 @@ import retrieveProjectMetadata from './handlers/file/projectMetadataHandler';
 import readRecentProjects from './handlers/file/readRecentProjects';
 import requestMediaDialog from './handlers/file/requestMediaDialog';
 import saveAsProject from './handlers/file/saveAsProjectHandler';
+import saveChangesDialog from './handlers/file/saveChangesDialog';
 import saveProject from './handlers/file/saveProjectHandler';
 import writeRecentProjects from './handlers/file/writeRecentProjects';
 import extractAudio from './handlers/media/audioExtract';
@@ -19,6 +20,7 @@ import exportProject from './handlers/media/exportProjectHandler';
 import extractThumbnail from './handlers/media/thumbnailExtract';
 import loadThumbnail from './handlers/media/thumbnailLoad';
 import requestTranscription from './handlers/media/transcriptionHandler';
+import setExportEnabled from './handlers/menu/setExportEnabled';
 import setFileRepresentation from './handlers/menu/setFileRepresentation';
 import setHomeEnabled from './handlers/menu/setHomeEnabled';
 import setSaveEnabled from './handlers/menu/setSaveEnabled';
@@ -30,7 +32,6 @@ import closeWindow from './handlers/window/closeWindow';
 import promptSave from './handlers/window/promptSave';
 import returnToHome from './handlers/window/returnToHomeHandler';
 import showConfirmation from './handlers/window/showConfirmation';
-import setExportEnabled from './handlers/menu/setExportEnabled';
 // END GENERATED CODE PART 1
 
 const initialiseIpcHandlers: (ipcContext: IpcContext) => void = (
@@ -57,6 +58,12 @@ const initialiseIpcHandlers: (ipcContext: IpcContext) => void = (
 
   ipcMain.handle('save-as-project', async (_event, project) =>
     saveAsProject(ipcContext, project)
+  );
+
+  ipcMain.handle(
+    'save-changes-dialog',
+    async (_event, mainWindow, projectFileName) =>
+      saveChangesDialog(mainWindow, projectFileName)
   );
 
   ipcMain.handle('save-project', async (_event, project) =>
@@ -89,6 +96,10 @@ const initialiseIpcHandlers: (ipcContext: IpcContext) => void = (
     requestTranscription(project)
   );
 
+  ipcMain.handle('set-export-enabled', async (_event, exportEnabled) =>
+    setExportEnabled(ipcContext, exportEnabled)
+  );
+
   ipcMain.handle(
     'set-file-representation',
     async (_event, representedFilePath, isEdited) =>
@@ -103,10 +114,6 @@ const initialiseIpcHandlers: (ipcContext: IpcContext) => void = (
     'set-save-enabled',
     async (_event, saveEnabled, saveAsEnabled) =>
       setSaveEnabled(ipcContext, saveEnabled, saveAsEnabled)
-  );
-
-  ipcMain.handle('set-export-enabled', async (_event, exportEnabled) =>
-    setExportEnabled(ipcContext, exportEnabled)
   );
 
   ipcMain.handle(

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -17,6 +17,9 @@ contextBridge.exposeInMainWorld('electron', {
 
   saveAsProject: (project) => ipcRenderer.invoke('save-as-project', project),
 
+  saveChangesDialog: (mainWindow, projectFileName) =>
+    ipcRenderer.invoke('save-changes-dialog', mainWindow, projectFileName),
+
   saveProject: (project) => ipcRenderer.invoke('save-project', project),
 
   writeRecentProjects: (recentProjects) =>
@@ -34,6 +37,9 @@ contextBridge.exposeInMainWorld('electron', {
   requestTranscription: (project) =>
     ipcRenderer.invoke('request-transcription', project),
 
+  setExportEnabled: (exportEnabled) =>
+    ipcRenderer.invoke('set-export-enabled', exportEnabled),
+
   setFileRepresentation: (representedFilePath, isEdited) =>
     ipcRenderer.invoke(
       'set-file-representation',
@@ -46,9 +52,6 @@ contextBridge.exposeInMainWorld('electron', {
 
   setSaveEnabled: (saveEnabled, saveAsEnabled) =>
     ipcRenderer.invoke('set-save-enabled', saveEnabled, saveAsEnabled),
-
-  setExportEnabled: (exportEnabled) =>
-    ipcRenderer.invoke('set-export-enabled', exportEnabled),
 
   setUndoRedoEnabled: (undoEnabled, redoEnabled) =>
     ipcRenderer.invoke('set-undo-redo-enabled', undoEnabled, redoEnabled),

--- a/src/main/promptToSaveWork.ts
+++ b/src/main/promptToSaveWork.ts
@@ -1,10 +1,8 @@
 import { BrowserWindow } from 'electron';
 import path from 'path';
 import AppState from './AppState';
-import {
-  saveChangesDialog,
-  SaveDialogSelections,
-} from './handlers/file/saveChangesDialog';
+import saveChangesDialog from './handlers/file/saveChangesDialog';
+import { SaveDialogSelections } from './handlers/helpers/saveDialog';
 
 /**
  * Prompts the user to save their work when they close the app

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -34,6 +34,11 @@ declare global {
 
       saveAsProject: (project: RuntimeProject) => Promise<string>;
 
+      saveChangesDialog: (
+        mainWindow: BrowserWindow,
+        projectFileName?: string
+      ) => SaveDialogSelections;
+
       saveProject: (project: RuntimeProject) => Promise<string>;
 
       writeRecentProjects: (recentProjects: RecentProject[]) => Promise<void>;
@@ -53,6 +58,8 @@ declare global {
         project: RuntimeProject
       ) => Promise<Transcription | null>;
 
+      setExportEnabled: (exportEnabled: boolean) => void;
+
       setFileRepresentation: (
         representedFilePath: string | null,
         isEdited: boolean
@@ -63,8 +70,6 @@ declare global {
       setSaveEnabled: (saveEnabled: boolean, saveAsEnabled: boolean) => void;
 
       setUndoRedoEnabled: (undoEnabled: boolean, redoEnabled: boolean) => void;
-
-      setExportEnabled: (exportEnabled: boolean) => void;
 
       getFileNameWithExtension: (filePath: string | null) => Promise<string>;
 


### PR DESCRIPTION
Resolves #181

Due to some quirks with the codegen, handler files can only have a single export. I've moved the second export (SaveDialogSelections) into a helper file instead

Take a look at GENCODE_README.md for further detail. I don't think the single export requirement is mentioned though the must-be-a-default-export one is. And I know it's a dumb requirement, a few shortcuts were taken in the gencode implementation to make it a bit quicker to build.