### PR TITLE
Clean up ops, utils and StoreObserver

### DIFF
--- a/src/renderer/StoreChangeObserver.tsx
+++ b/src/renderer/StoreChangeObserver.tsx
@@ -3,6 +3,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { recentProjectsLoaded } from './store/recentProjects/actions';
 import { ApplicationStore } from './store/sharedHelpers';
 import ipc from './ipc';
+import { ApplicationPage } from './store/currentPage/helpers';
 
 const { readRecentProjects, writeRecentProjects } = ipc;
 
@@ -14,6 +15,14 @@ export default function StoreChangeObserver() {
   const currentProject = useSelector(
     (store: ApplicationStore) => store.currentProject
   );
+
+  const currentPage = useSelector(
+    (store: ApplicationStore) => store.currentPage
+  );
+
+  const clipboard = useSelector((store: ApplicationStore) => store.clipboard);
+
+  const selection = useSelector((store: ApplicationStore) => store.selection);
 
   const [hasLoadedRecentProjects, setHasLoadedRecentProjects] =
     useState<boolean>(false);
@@ -79,6 +88,27 @@ export default function StoreChangeObserver() {
       );
     }
   }, [currentProject, isProjectEdited, setProjectEdited]);
+
+  // Update 'go to home' option in menu when page is changed
+  useEffect(() => {
+    const homeEnabled = currentPage === ApplicationPage.PROJECT;
+
+    ipc.setHomeEnabled(homeEnabled);
+  }, [currentPage]);
+
+  // Update clipboard options in edit menu when clipboard or selection is changed
+  useEffect(() => {
+    const cutCopyDeleteEnabled = selection.length > 0;
+
+    const pasteEnabled = clipboard.length > 0;
+
+    ipc.setClipboardEnabled(
+      cutCopyDeleteEnabled,
+      cutCopyDeleteEnabled,
+      pasteEnabled,
+      cutCopyDeleteEnabled
+    );
+  }, [clipboard, selection]);
 
   // Component doesn't render anything
   return null;

--- a/src/renderer/StoreChangeObserver.tsx
+++ b/src/renderer/StoreChangeObserver.tsx
@@ -100,7 +100,8 @@ export default function StoreChangeObserver() {
   useEffect(() => {
     const cutCopyDeleteEnabled = selection.length > 0;
 
-    const pasteEnabled = clipboard.length > 0;
+    // Selection must not be empty as we need somewhere to paste to
+    const pasteEnabled = selection.length > 0 && clipboard.length > 0;
 
     ipc.setClipboardEnabled(
       cutCopyDeleteEnabled,

--- a/src/renderer/__tests__/selection.test.ts
+++ b/src/renderer/__tests__/selection.test.ts
@@ -1,5 +1,5 @@
 import { SELECTION_RANGE_ADDED } from 'renderer/store/selection/actions';
-import { expandSelectionToWord, getSelectionRanges } from '../selection';
+import { expandSelectionToWord, getSelectionRanges } from '../editor/selection';
 import { ApplicationStore, initialStore } from '../store/sharedHelpers';
 import store from '../store/store';
 

--- a/src/renderer/components/Word.tsx
+++ b/src/renderer/components/Word.tsx
@@ -9,7 +9,7 @@ import {
 import { MousePosition } from '@react-hook/mouse-position';
 import { pointIsInsideRect } from 'renderer/util';
 import colors from '../colors';
-import { handleSelectWord } from '../selection';
+import { handleSelectWord } from '../editor/selection';
 import { DragState } from './WordDragManager';
 
 const makeWordInner = (isDragActive: boolean) =>

--- a/src/renderer/editor/clipboard.ts
+++ b/src/renderer/editor/clipboard.ts
@@ -1,9 +1,9 @@
-import { Word } from '../sharedTypes';
+import { Word } from '../../sharedTypes';
 import { getSelectionRanges } from './selection';
-import { clipboardUpdated } from './store/clipboard/actions';
-import store from './store/store';
-import { dispatchOp } from './store/undoStack/opHelpers';
-import { makeDeleteSelection, makePasteWord } from './store/undoStack/ops';
+import { clipboardUpdated } from '../store/clipboard/actions';
+import store from '../store/store';
+import { dispatchOp } from '../store/undoStack/opHelpers';
+import { makeDeleteSelection, makePasteWord } from '../store/undoStack/ops';
 
 const { dispatch } = store;
 

--- a/src/renderer/editor/clipboard.ts
+++ b/src/renderer/editor/clipboard.ts
@@ -16,19 +16,14 @@ const pasteWord = (afterWordIndex: number, clipboard: Word[]) => {
 };
 
 export const copyText = () => {
-  const { currentProject } = store.getState();
-  if (currentProject === null) {
-    return;
-  }
-
-  const { transcription } = currentProject;
-  if (transcription === null) {
+  const words = store.getState().currentProject?.transcription?.words;
+  if (words === undefined) {
     return;
   }
 
   const ranges = getSelectionRanges();
   const clipboard = ranges.flatMap((range) =>
-    transcription.words.slice(range.startIndex, range.endIndex)
+    words.slice(range.startIndex, range.endIndex)
   );
   dispatch(clipboardUpdated(clipboard));
 };

--- a/src/renderer/editor/selection.ts
+++ b/src/renderer/editor/selection.ts
@@ -1,12 +1,12 @@
-import { IndexRange, OperatingSystems } from '../sharedTypes';
-import ipc from './ipc';
+import { IndexRange, OperatingSystems } from '../../sharedTypes';
+import ipc from '../ipc';
 import {
   selectionCleared,
   selectionRangeAdded,
   selectionRangeToggled,
-} from './store/selection/actions';
-import store from './store/store';
-import { rangeLengthOne, sortNumerical } from './util';
+} from '../store/selection/actions';
+import store from '../store/store';
+import { rangeLengthOne, sortNumerical } from '../util';
 
 const { dispatch } = store;
 

--- a/src/renderer/editor/selection.ts
+++ b/src/renderer/editor/selection.ts
@@ -6,7 +6,7 @@ import {
   selectionRangeToggled,
 } from '../store/selection/actions';
 import store from '../store/store';
-import { rangeLengthOne, sortNumerical } from '../util';
+import { indicesToRanges, rangeLengthOne, sortNumerical } from '../util';
 
 const { dispatch } = store;
 
@@ -14,54 +14,9 @@ const { dispatch } = store;
  * Returns a list of ranges consisting of the selected words' indexes
  */
 export const getSelectionRanges: () => IndexRange[] = () => {
-  const { selection: selectionFromState } = store.getState();
+  const { selection } = store.getState();
 
-  // store.getState() does not return copies, so make a copy to avoid mutating the state
-  const selection = [...selectionFromState];
-
-  // Sort the indices
-  sortNumerical(selection);
-
-  let currentStartIndex = selection[0];
-
-  /**
-   * This reduce is similar to the 'convertTranscriptToCuts' function, so refer to that
-   * for comments about the general approach.
-   * What is being achieved is turning a sorted array of indexes into a series of
-   * index ranges. For a contiguous selection, there will only be one index range.
-   */
-  const indexRanges: IndexRange[] = selection.reduce(
-    (rangesSoFar, currentIndex, j) => {
-      // Note: j refers to the index within this loop, not the index within the transcription itself.
-      const isFinalWord = j === selection.length - 1;
-
-      // Final element, so build a range no matter what
-      if (isFinalWord) {
-        return rangesSoFar.concat({
-          startIndex: currentStartIndex,
-          endIndex: currentIndex + 1,
-        });
-      }
-
-      const nextIndex = selection[j + 1];
-
-      if (currentIndex + 1 === nextIndex) {
-        return rangesSoFar;
-      }
-
-      const newRange: IndexRange = {
-        startIndex: currentStartIndex,
-        endIndex: currentIndex + 1,
-      };
-
-      currentStartIndex = nextIndex;
-
-      return rangesSoFar.concat(newRange);
-    },
-    [] as IndexRange[]
-  );
-
-  return indexRanges;
+  return indicesToRanges(selection);
 };
 
 export const expandSelectionToWord: (wordIndex: number) => void = (

--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -8,6 +8,7 @@ const mockIpc = {
   setFileRepresentation: () => null,
   openProject: async () => null,
   setClipboardEnabled: async () => null,
+  setHomeEnabled: async () => null,
 };
 
 const ipc = window.electron ?? mockIpc;

--- a/src/renderer/ipcRegistration.ts
+++ b/src/renderer/ipcRegistration.ts
@@ -151,24 +151,19 @@ ipc.on('initiate-export-project', async () => {
   store.dispatch(startExport(currentProject.id, filePath));
 });
 
-ipc.on('initiate-cut-text', async () => {
-  cutText();
-});
+const EDITOR_ACTIONS: Record<string, () => void> = {
+  'initiate-cut-text': cutText,
+  'initiate-copy-text': copyText,
+  'initiate-paste-text': pasteText,
+  'initiate-delete-text': deleteText,
+  'initiate-select-all': selectAllWords,
+};
 
-ipc.on('initiate-copy-text', async () => {
-  copyText();
-});
-
-ipc.on('initiate-paste-text', async () => {
-  pasteText();
-});
-
-ipc.on('initiate-delete-text', async () => {
-  deleteText();
-});
-
-ipc.on('initiate-select-all', async () => {
-  selectAllWords();
+// Register the editor actions as IPC receivers
+Object.keys(EDITOR_ACTIONS).forEach((key) => {
+  ipc.on(key, async () => {
+    EDITOR_ACTIONS[key]();
+  });
 });
 
 /**

--- a/src/renderer/ipcRegistration.ts
+++ b/src/renderer/ipcRegistration.ts
@@ -16,8 +16,8 @@ import { ApplicationPage } from './store/currentPage/helpers';
 import { dispatchRedo, dispatchUndo } from './store/undoStack/opHelpers';
 import store from './store/store';
 import { removeExtension } from './util';
-import { copyText, cutText, deleteText, pasteText } from './clipboard';
-import { selectAllWords } from './selection';
+import { copyText, cutText, deleteText, pasteText } from './editor/clipboard';
+import { selectAllWords } from './editor/selection';
 
 /**
  * Used by backend to initiate saves from front end

--- a/src/renderer/store/clipboard/actions.ts
+++ b/src/renderer/store/clipboard/actions.ts
@@ -1,26 +1,12 @@
-import ipc from 'renderer/ipc';
 import { Word } from 'sharedTypes';
 import { Action } from '../action';
 
 export const CLIPBOARD_UPDATED = 'CLIPBOARD_UPDATED';
 
-const updateClipboardEnabledInMenu: (clipboard: Word[]) => void = (
-  clipboard
-) => {
-  const pasteEnabled = clipboard.length > 0;
-
-  // TODO(chloe): smarter logic for this (only enabled cut, copy, delete if there is a selection, etc).
-  ipc.setClipboardEnabled(true, true, pasteEnabled, true);
-};
-
 // Action to update the clipboard contents when words are copied
 export const clipboardUpdated: (clipboard: Word[]) => Action<Word[]> = (
   clipboard
-) => {
-  updateClipboardEnabledInMenu(clipboard);
-
-  return {
-    type: CLIPBOARD_UPDATED,
-    payload: clipboard,
-  };
-};
+) => ({
+  type: CLIPBOARD_UPDATED,
+  payload: clipboard,
+});

--- a/src/renderer/store/currentPage/actions.ts
+++ b/src/renderer/store/currentPage/actions.ts
@@ -1,23 +1,11 @@
-import ipc from '../../ipc';
 import { Action } from '../action';
 import { ApplicationPage } from './helpers';
 
 export const PAGE_CHANGED = 'PAGE_CHANGED';
 
-const { setHomeEnabled } = ipc;
-
-const updateHomeEnabledInMenu: (page: ApplicationPage) => void = (page) => {
-  const homeEnabled = page === ApplicationPage.PROJECT;
-
-  setHomeEnabled(homeEnabled);
-};
-
 export const pageChanged: (page: ApplicationPage) => Action<ApplicationPage> = (
   page
-) => {
-  updateHomeEnabledInMenu(page);
-  return {
-    type: PAGE_CHANGED,
-    payload: page,
-  };
-};
+) => ({
+  type: PAGE_CHANGED,
+  payload: page,
+});

--- a/src/renderer/store/selection/actions.ts
+++ b/src/renderer/store/selection/actions.ts
@@ -14,55 +14,45 @@ export const SELECTION_CLEARED = 'SELECTION_CLEARED';
  */
 export const selectionRangeAdded: (
   indexRange: IndexRange
-) => Action<IndexRange> = (indexRange) => {
-  return {
-    type: SELECTION_RANGE_ADDED,
-    payload: indexRange,
-  };
-};
+) => Action<IndexRange> = (indexRange) => ({
+  type: SELECTION_RANGE_ADDED,
+  payload: indexRange,
+});
 
 /**
  * Same as selectionRangeAdded, but for an item or range that is removed.
  */
 export const selectionRangeRemoved: (
   indexRange: IndexRange
-) => Action<IndexRange> = (indexRange) => {
-  return {
-    type: SELECTION_RANGE_REMOVED,
-    payload: indexRange,
-  };
-};
+) => Action<IndexRange> = (indexRange) => ({
+  type: SELECTION_RANGE_REMOVED,
+  payload: indexRange,
+});
 
 /**
  * Same as selectionRangeAdded, but for each item in the range, toggle whether it is selected or not.
  */
 export const selectionRangeToggled: (
   indexRange: IndexRange
-) => Action<IndexRange> = (indexRange) => {
-  return {
-    type: SELECTION_RANGE_TOGGLED,
-    payload: indexRange,
-  };
-};
+) => Action<IndexRange> = (indexRange) => ({
+  type: SELECTION_RANGE_TOGGLED,
+  payload: indexRange,
+});
 
 /**
  * Efficiently sets the range to be a certain value.
  */
 export const selectionRangeSetTo: (
   indexRange: IndexRange
-) => Action<IndexRange> = (indexRange) => {
-  return {
-    type: SELECTION_RANGE_SET_TO,
-    payload: indexRange,
-  };
-};
+) => Action<IndexRange> = (indexRange) => ({
+  type: SELECTION_RANGE_SET_TO,
+  payload: indexRange,
+});
 
 /**
  * Action that clears the active selection.
  */
-export const selectionCleared: () => Action<null> = () => {
-  return {
-    type: SELECTION_CLEARED,
-    payload: null,
-  };
-};
+export const selectionCleared: () => Action<null> = () => ({
+  type: SELECTION_CLEARED,
+  payload: null,
+});

--- a/src/renderer/store/undoStack/helpers.ts
+++ b/src/renderer/store/undoStack/helpers.ts
@@ -1,5 +1,9 @@
+import { IndexRange } from 'sharedTypes';
 import { DoPayload, UndoPayload } from './opPayloads';
 import { Action } from '../action';
+
+// Selection payloads can be applied to any op do or undo
+export type SelectionPayload = IndexRange | null;
 
 /**
  * An Op is a representation of an action that can be both done and undone.
@@ -8,8 +12,8 @@ import { Action } from '../action';
  * The list of 'undo' actions is represented in the order the actions are undone.
  */
 export interface Op<T extends DoPayload, U extends UndoPayload> {
-  do: Action<T>[];
-  undo: Action<U>[];
+  do: Action<T | SelectionPayload>[];
+  undo: Action<U | SelectionPayload>[];
 }
 
 /**


### PR DESCRIPTION
Various clean ups that were originally done for https://github.com/chloebrett/mlvet/pull/183 but weren't relevant to that PR.

- Group selection and clipboard files into new `editor` folder
- Programmatically register IPC handlers on front end
- Make actions pure functions
- Make store observer handle menu updates for clipboard and page change actions