### PR TITLE
Manually register keyboard handlers on win/linux

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -4,4 +4,4 @@ import { TranscriptionEngine } from './handlers/helpers/transcribeTypes';
 
 // Which transcription engine to use for any transcription.
 // This will eventually be replaced with a config file allowing the user to choose which engine they want
-export const TRANSCRIPTION_ENGINE = TranscriptionEngine.DUMMY;
+export const TRANSCRIPTION_ENGINE = TranscriptionEngine.DEEPSPEECH;

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -4,4 +4,4 @@ import { TranscriptionEngine } from './handlers/helpers/transcribeTypes';
 
 // Which transcription engine to use for any transcription.
 // This will eventually be replaced with a config file allowing the user to choose which engine they want
-export const TRANSCRIPTION_ENGINE = TranscriptionEngine.DEEPSPEECH;
+export const TRANSCRIPTION_ENGINE = TranscriptionEngine.DUMMY;

--- a/src/renderer/ipcRegistration.ts
+++ b/src/renderer/ipcRegistration.ts
@@ -10,6 +10,7 @@ import exportProject from './file/exportProject';
 import returnToHome from './navigation/returnToHome';
 import { performUndo, performRedo } from './editor/undoRedo';
 import { mergeWords, splitWord } from './editor/mergeSplit';
+import registerKeyboardHandlers from './keyboardShortcutsRegistration';
 
 const IPC_RECEIVERS: Record<string, (...args: any[]) => void> = {
   // File actions
@@ -55,3 +56,6 @@ const registerIpcHandler: (
 Object.keys(IPC_RECEIVERS).forEach((key) =>
   registerIpcHandler(key, IPC_RECEIVERS[key])
 );
+
+// Also register the manual keyboard handlers for windows/linux
+registerKeyboardHandlers();

--- a/src/renderer/keyboardShortcutsRegistration.ts
+++ b/src/renderer/keyboardShortcutsRegistration.ts
@@ -1,0 +1,42 @@
+/**
+ * On Windows and Linux, for some undiagnosed reason, some (but not all)
+ * keyboard shortcuts don't work. This file resolves that issue by manually
+ * re-registering the handlers for the specific affected shortcuts.
+ */
+
+import { OperatingSystems } from 'sharedTypes';
+import { copyText, cutText, pasteText } from './editor/clipboard';
+import { selectAllWords } from './editor/selection';
+import ipc from './ipc';
+
+/**
+ * Each key represents pressing Ctrl plus that key.
+ */
+const keyToHandlerMap: Record<string, () => void> = {
+  x: cutText,
+  c: copyText,
+  v: pasteText,
+  a: selectAllWords,
+};
+
+const registerKeyboardHandlers: () => Promise<void> = async () => {
+  const os = await ipc.handleOsQuery();
+
+  // Issue only affects Windows and Linux, so ignore for Mac
+  if (os === null || os === OperatingSystems.MACOS) {
+    return;
+  }
+
+  window.onkeydown = (event: KeyboardEvent) => {
+    if (!event.ctrlKey) {
+      return;
+    }
+
+    if (Object.keys(keyToHandlerMap).includes(event.key)) {
+      // Invoke the appropriate handler
+      keyToHandlerMap[event.key]();
+    }
+  };
+};
+
+export default registerKeyboardHandlers;


### PR DESCRIPTION
Resolves #180 

Small fix for a big problem 😜 

Seems to work on my linux machine. Not perfect (e.g. macos blocks the native select all because it's overwritten with our custom one, whereas this doesn't) but I think it gets the job done. At the very least, cut/copy/paste appear to work flawlessly 🙂 