### PR TITLE
fixing constant to match requirement for algorithmic sentence sim

### DIFF
--- a/src/main/takeDetection/constants.ts
+++ b/src/main/takeDetection/constants.ts
@@ -1,2 +1,2 @@
 // eslint-disable-next-line import/prefer-default-export
-export const THRESHOLD = 0.65;
+export const THRESHOLD = 0.7;


### PR DESCRIPTION
## Summary

Fixed the constant so it's the right value for algorithmic sentence similarity instead of ML sentence similarity

### OS

- [ ] Linux
- [ ] MacOS
- [x] Windows
