### PR TITLE
Cloud config cherry pick

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -1,14 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 
 import { TranscriptionEngine } from '../sharedTypes';
-import readDefaultEngineConfig from './handlers/file/readDefaultEngineConfig';
 
 // Which transcription engine to use for any transcription.
 // This will eventually be replaced with a config file allowing the user to choose which engine they want
 export const TRANSCRIPTION_ENGINE = TranscriptionEngine.ASSEMBLYAI;
-
-export const DEFAULT_ENGINE_CONFIG = readDefaultEngineConfig().then(
-  (engineConfig) => {
-    return engineConfig ?? '';
-  }
-);

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -1,9 +1,14 @@
 /* eslint-disable import/prefer-default-export */
 
 import { TranscriptionEngine } from '../sharedTypes';
+import readDefaultEngineConfig from './handlers/file/readDefaultEngineConfig';
 
 // Which transcription engine to use for any transcription.
 // This will eventually be replaced with a config file allowing the user to choose which engine they want
 export const TRANSCRIPTION_ENGINE = TranscriptionEngine.ASSEMBLYAI;
 
-export const ASSEMBLYAI_API_KEY = '';
+export const DEFAULT_ENGINE_CONFIG = readDefaultEngineConfig().then(
+  (engineConfig) => {
+    return engineConfig ?? '';
+  }
+);

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -6,4 +6,4 @@ import { TranscriptionEngine } from '../sharedTypes';
 // This will eventually be replaced with a config file allowing the user to choose which engine they want
 export const TRANSCRIPTION_ENGINE = TranscriptionEngine.ASSEMBLYAI;
 
-export const ASSEMBLYAI_API_KEY = 'readCloudCredentials()';
+export const ASSEMBLYAI_API_KEY = '';

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -1,7 +1,9 @@
 /* eslint-disable import/prefer-default-export */
 
-import { TranscriptionEngine } from './handlers/helpers/transcribeTypes';
+import { TranscriptionEngine } from '../sharedTypes';
 
 // Which transcription engine to use for any transcription.
 // This will eventually be replaced with a config file allowing the user to choose which engine they want
-export const TRANSCRIPTION_ENGINE = TranscriptionEngine.DUMMY;
+export const TRANSCRIPTION_ENGINE = TranscriptionEngine.ASSEMBLYAI;
+
+export const ASSEMBLYAI_API_KEY = 'readCloudCredentials()';

--- a/src/main/handlers/file/readCloudConfig.ts
+++ b/src/main/handlers/file/readCloudConfig.ts
@@ -1,18 +1,13 @@
-import { unlinkSync, readFileSync } from 'fs';
+import { readFileSync } from 'fs';
 import { CloudConfig } from 'sharedTypes';
-import { appCloudConfigPath, fileOrDirExists } from '../../util';
+import { appCloudConfigPath } from '../../util';
 
-type ReadCloudCredentials = () => Promise<CloudConfig>;
+type ReadCloudConfig = () => Promise<CloudConfig>;
 
-const readCloudCredentials: ReadCloudCredentials = async () => {
+const readCloudConfig: ReadCloudConfig = async () => {
   const cloudConfigPath = appCloudConfigPath();
 
-  if (fileOrDirExists(cloudConfigPath)) {
-    unlinkSync(cloudConfigPath);
-  }
-
   const cloudConfigBuffer = readFileSync(cloudConfigPath);
-
   try {
     const cloudConfigString = cloudConfigBuffer.toString();
     const cloudConfig: CloudConfig = JSON.parse(cloudConfigString);
@@ -22,4 +17,4 @@ const readCloudCredentials: ReadCloudCredentials = async () => {
   }
 };
 
-export default readCloudCredentials;
+export default readCloudConfig;

--- a/src/main/handlers/file/readCloudCredentials.ts
+++ b/src/main/handlers/file/readCloudCredentials.ts
@@ -1,0 +1,25 @@
+import { unlinkSync, readFileSync } from 'fs';
+import { CloudConfig } from 'sharedTypes';
+import { appCloudConfigPath, fileOrDirExists } from '../../util';
+
+type ReadCloudCredentials = () => Promise<CloudConfig>;
+
+const readCloudCredentials: ReadCloudCredentials = async () => {
+  const cloudConfigPath = appCloudConfigPath();
+
+  if (fileOrDirExists(cloudConfigPath)) {
+    unlinkSync(cloudConfigPath);
+  }
+
+  const cloudConfigBuffer = readFileSync(cloudConfigPath);
+
+  try {
+    const cloudConfigString = cloudConfigBuffer.toString();
+    const cloudConfig: CloudConfig = JSON.parse(cloudConfigString);
+    return cloudConfig;
+  } catch (err) {
+    throw new Error(`Error cloud config file: ${err}`);
+  }
+};
+
+export default readCloudCredentials;

--- a/src/main/handlers/file/readDefaultEngineConfig.ts
+++ b/src/main/handlers/file/readDefaultEngineConfig.ts
@@ -1,0 +1,20 @@
+import { EngineConfig } from '../../../sharedTypes';
+import { findDefaultEngineConfig } from '../../../sharedUtils';
+import { appCloudConfigPath, fileOrDirExists } from '../../util';
+import readCloudConfig from './readCloudConfig';
+
+type ReadDefaultEngineConfig = () => Promise<EngineConfig>;
+
+const readDefaultEngineConfig: ReadDefaultEngineConfig = async () => {
+  if (!fileOrDirExists(appCloudConfigPath())) {
+    const cloudConfig = await readCloudConfig();
+    if (cloudConfig !== null) {
+      const defaultEngineConfig = findDefaultEngineConfig(cloudConfig);
+      return defaultEngineConfig;
+    }
+  }
+
+  return null;
+};
+
+export default readDefaultEngineConfig;

--- a/src/main/handlers/file/readDefaultEngineConfig.ts
+++ b/src/main/handlers/file/readDefaultEngineConfig.ts
@@ -6,7 +6,7 @@ import readCloudConfig from './readCloudConfig';
 type ReadDefaultEngineConfig = () => Promise<EngineConfig>;
 
 const readDefaultEngineConfig: ReadDefaultEngineConfig = async () => {
-  if (!fileOrDirExists(appCloudConfigPath())) {
+  if (fileOrDirExists(appCloudConfigPath())) {
     const cloudConfig = await readCloudConfig();
     if (cloudConfig !== null) {
       const defaultEngineConfig = findDefaultEngineConfig(cloudConfig);

--- a/src/main/handlers/file/requireCloudConfig.ts
+++ b/src/main/handlers/file/requireCloudConfig.ts
@@ -1,12 +1,17 @@
+import { getDefaultEngineConfig } from '../../../sharedUtils';
 import { appCloudConfigPath, fileOrDirExists } from '../../util';
+import readCloudConfig from './readCloudConfig';
 
 type RequireCloudConfig = () => Promise<boolean>;
 
 const requireCloudConfig: RequireCloudConfig = async () => {
   const cloudConfigPath = appCloudConfigPath();
-
-  // if not exists (false) we want to negate so the frontend can add the cloud config view.
-  return !fileOrDirExists(cloudConfigPath);
+  if (fileOrDirExists(cloudConfigPath)) {
+    const cloudConfig = await readCloudConfig();
+    const engineConfig = getDefaultEngineConfig(cloudConfig);
+    return engineConfig === null;
+  }
+  return true;
 };
 
 export default requireCloudConfig;

--- a/src/main/handlers/file/requireCloudConfig.ts
+++ b/src/main/handlers/file/requireCloudConfig.ts
@@ -1,4 +1,4 @@
-import { getDefaultEngineConfig } from '../../../sharedUtils';
+import { findDefaultEngineConfig } from '../../../sharedUtils';
 import { appCloudConfigPath, fileOrDirExists } from '../../util';
 import readCloudConfig from './readCloudConfig';
 
@@ -8,7 +8,7 @@ const requireCloudConfig: RequireCloudConfig = async () => {
   const cloudConfigPath = appCloudConfigPath();
   if (fileOrDirExists(cloudConfigPath)) {
     const cloudConfig = await readCloudConfig();
-    const engineConfig = getDefaultEngineConfig(cloudConfig);
+    const engineConfig = findDefaultEngineConfig(cloudConfig);
     return engineConfig === null;
   }
   return true;

--- a/src/main/handlers/file/storeCloudCredentials.ts
+++ b/src/main/handlers/file/storeCloudCredentials.ts
@@ -58,10 +58,8 @@ const storeCloudCredentials: StoreCloudCredentials = async (
           cloudConfig
         );
 
-        console.log(`${JSON.stringify(updatedCloudConfig)}ready`);
-
         writeFileSync(cloudConfigPath, JSON.stringify(updatedCloudConfig));
-        console.log(`${readFileSync(cloudConfigPath)}read`);
+
         return updatedCloudConfig;
       })
       .catch((err) => {
@@ -74,9 +72,7 @@ const storeCloudCredentials: StoreCloudCredentials = async (
       initCloudConfig
     );
 
-    console.log(JSON.stringify(newCloudConfig));
     writeFileSync(cloudConfigPath, JSON.stringify(newCloudConfig));
-    console.log(`${readFileSync(cloudConfigPath)}read`);
   }
 };
 

--- a/src/main/handlers/helpers/transcribeTypes.ts
+++ b/src/main/handlers/helpers/transcribeTypes.ts
@@ -8,10 +8,6 @@ export type TranscriptionFunction = (
 ) => Promise<JSONTranscription>;
 
 // Then add the new engine to this enum
-export enum TranscriptionEngine {
-  DUMMY,
-  ASSEMBLYAI,
-}
 
 // Then add associate the new transcription function with the enum in the
 // getTranscriptionFunction map in transcribe.ts

--- a/src/main/handlers/helpers/transcriptionEngines/assemblyAiTranscribeFunction.ts
+++ b/src/main/handlers/helpers/transcriptionEngines/assemblyAiTranscribeFunction.ts
@@ -6,7 +6,7 @@ import { JSONTranscription } from 'main/types';
 // Axios doesn't work for the file upload for some reason, so use node fetch instead.
 // Have to use a slightly older version (2.6.6) as well due to module issues
 import fetch from 'node-fetch';
-import { DEFAULT_ENGINE_CONFIG } from 'main/config';
+import { DEFAULT_ENGINE_CONFIG } from '../../../config';
 import { TranscriptionFunction } from '../transcribeTypes';
 import { getAudioExtractPath, roundToMs } from '../../../util';
 

--- a/src/main/handlers/helpers/transcriptionEngines/assemblyAiTranscribeFunction.ts
+++ b/src/main/handlers/helpers/transcriptionEngines/assemblyAiTranscribeFunction.ts
@@ -2,11 +2,11 @@ import fs from 'fs/promises';
 import axios, { AxiosError } from 'axios';
 import queryString from 'query-string';
 import { JSONTranscription } from 'main/types';
+import fetch from 'node-fetch';
+import readDefaultEngineConfig from '../../file/readDefaultEngineConfig';
 
 // Axios doesn't work for the file upload for some reason, so use node fetch instead.
 // Have to use a slightly older version (2.6.6) as well due to module issues
-import fetch from 'node-fetch';
-import { DEFAULT_ENGINE_CONFIG } from '../../../config';
 import { TranscriptionFunction } from '../transcribeTypes';
 import { getAudioExtractPath, roundToMs } from '../../../util';
 
@@ -20,8 +20,11 @@ const AUTH_ERROR_STRING = 'Authentication error, API token missing/invalid';
 
 class ApiTokenError extends Error {}
 
+const getApiKey = () => readDefaultEngineConfig().then((val) => val ?? '');
+
 const uploadAudio = async (audioPath: string) => {
-  const ASSEMBLYAI_API_KEY = await DEFAULT_ENGINE_CONFIG;
+  const ASSEMBLYAI_API_KEY = await getApiKey();
+  console.log(ASSEMBLYAI_API_KEY);
   const data = await fs.readFile(audioPath);
 
   const url = 'https://api.assemblyai.com/v2/upload';
@@ -46,7 +49,7 @@ const uploadAudio = async (audioPath: string) => {
 const initTranscription: (audioUrl: string) => Promise<string> = async (
   audioUrl
 ) => {
-  const ASSEMBLYAI_API_KEY = await DEFAULT_ENGINE_CONFIG;
+  const ASSEMBLYAI_API_KEY = await getApiKey();
   const endpoint = 'https://api.assemblyai.com/v2/transcript';
 
   const jsonData = {
@@ -78,7 +81,7 @@ const initTranscription: (audioUrl: string) => Promise<string> = async (
 };
 
 const pollTranscriptionResultInner = async (transcriptionId: string) => {
-  const ASSEMBLYAI_API_KEY = await DEFAULT_ENGINE_CONFIG;
+  const ASSEMBLYAI_API_KEY = await getApiKey();
   const endpoint = `https://api.assemblyai.com/v2/transcript/${transcriptionId}`;
 
   const headers = {

--- a/src/main/handlers/helpers/transcriptionEngines/assemblyAiTranscribeFunction.ts
+++ b/src/main/handlers/helpers/transcriptionEngines/assemblyAiTranscribeFunction.ts
@@ -6,6 +6,7 @@ import { JSONTranscription } from 'main/types';
 // Axios doesn't work for the file upload for some reason, so use node fetch instead.
 // Have to use a slightly older version (2.6.6) as well due to module issues
 import fetch from 'node-fetch';
+import { ASSEMBLYAI_API_KEY } from '../../../config';
 import { TranscriptionFunction } from '../transcribeTypes';
 import { getAudioExtractPath, roundToMs } from '../../../util';
 
@@ -13,7 +14,7 @@ const sleep: (seconds: number) => Promise<void> = (seconds) =>
   new Promise((resolve) => setTimeout(resolve, seconds * 1000));
 
 // TODO: put in config
-const ASSEMBLYAI_API_KEY = 'fd0381ba0a274c09b2359005496fc79f';
+// const ASSEMBLYAI_API_KEY = 'fd0381ba0a274c09b2359005496fc79f';
 
 const AUTH_ERROR_STRING = 'Authentication error, API token missing/invalid';
 

--- a/src/main/handlers/helpers/transcriptionEngines/assemblyAiTranscribeFunction.ts
+++ b/src/main/handlers/helpers/transcriptionEngines/assemblyAiTranscribeFunction.ts
@@ -6,7 +6,7 @@ import { JSONTranscription } from 'main/types';
 // Axios doesn't work for the file upload for some reason, so use node fetch instead.
 // Have to use a slightly older version (2.6.6) as well due to module issues
 import fetch from 'node-fetch';
-import { ASSEMBLYAI_API_KEY } from '../../../config';
+import { DEFAULT_ENGINE_CONFIG } from 'main/config';
 import { TranscriptionFunction } from '../transcribeTypes';
 import { getAudioExtractPath, roundToMs } from '../../../util';
 
@@ -21,6 +21,7 @@ const AUTH_ERROR_STRING = 'Authentication error, API token missing/invalid';
 class ApiTokenError extends Error {}
 
 const uploadAudio = async (audioPath: string) => {
+  const ASSEMBLYAI_API_KEY = await DEFAULT_ENGINE_CONFIG;
   const data = await fs.readFile(audioPath);
 
   const url = 'https://api.assemblyai.com/v2/upload';
@@ -45,6 +46,7 @@ const uploadAudio = async (audioPath: string) => {
 const initTranscription: (audioUrl: string) => Promise<string> = async (
   audioUrl
 ) => {
+  const ASSEMBLYAI_API_KEY = await DEFAULT_ENGINE_CONFIG;
   const endpoint = 'https://api.assemblyai.com/v2/transcript';
 
   const jsonData = {
@@ -76,6 +78,7 @@ const initTranscription: (audioUrl: string) => Promise<string> = async (
 };
 
 const pollTranscriptionResultInner = async (transcriptionId: string) => {
+  const ASSEMBLYAI_API_KEY = await DEFAULT_ENGINE_CONFIG;
   const endpoint = `https://api.assemblyai.com/v2/transcript/${transcriptionId}`;
 
   const headers = {

--- a/src/main/handlers/media/transcribe.ts
+++ b/src/main/handlers/media/transcribe.ts
@@ -1,9 +1,6 @@
-import { RuntimeProject } from 'sharedTypes';
 import { JSONTranscription } from 'main/types';
-import {
-  TranscriptionEngine,
-  TranscriptionFunction,
-} from '../helpers/transcribeTypes';
+import { RuntimeProject, TranscriptionEngine } from '../../../sharedTypes';
+import { TranscriptionFunction } from '../helpers/transcribeTypes';
 import dummyTranscribeFunction from '../helpers/transcriptionEngines/dummyTranscribeFunction';
 import assemblyAiTranscribeFunction from '../helpers/transcriptionEngines/assemblyAiTranscribeFunction';
 

--- a/src/main/handlers/media/transcriptionHandler.ts
+++ b/src/main/handlers/media/transcriptionHandler.ts
@@ -1,5 +1,4 @@
 import ffmpeg from 'fluent-ffmpeg';
-import { TRANSCRIPTION_ENGINE } from '../../config';
 import {
   PartialWord,
   RuntimeProject,
@@ -9,6 +8,7 @@ import preProcessTranscript from '../../editDelete/preProcess';
 import { ffmpegPath, ffprobePath } from '../../ffUtils';
 import { JSONTranscription } from '../../types';
 import { getAudioExtractPath } from '../../util';
+import readCloudConfig from '../file/readCloudConfig';
 import transcribe from './transcribe';
 
 ffmpeg.setFfmpegPath(ffmpegPath);
@@ -60,7 +60,12 @@ const requestTranscription: RequestTranscription = async (project) => {
     return null;
   }
 
-  const transcript = await transcribe(project, TRANSCRIPTION_ENGINE);
+  const transcript = await transcribe(
+    project,
+    (
+      await readCloudConfig()
+    ).defaultEngine
+  );
 
   if (!validateJsonTranscription(transcript)) {
     throw new Error('JSON transcript is invalid');
@@ -69,7 +74,7 @@ const requestTranscription: RequestTranscription = async (project) => {
   const duration: number =
     (await getAudioDurationInSeconds(getAudioExtractPath(project.id))) || 0;
 
-  const processedTranscript = preProcessTranscript(transcript, duration, true);
+  const processedTranscript = preProcessTranscript(transcript, duration);
 
   return processedTranscript;
 };

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -11,6 +11,7 @@ import openExternalLink from './handlers/file/openLinkInExternalWindow';
 import openProject from './handlers/file/openProjectHandler';
 import retrieveProjectMetadata from './handlers/file/projectMetadataHandler';
 import readCloudConfig from './handlers/file/readCloudConfig';
+import readDefaultEngineConfig from './handlers/file/readDefaultEngineConfig';
 import readRecentProjects from './handlers/file/readRecentProjects';
 import requestMediaDialog from './handlers/file/requestMediaDialog';
 import requireCloudConfig from './handlers/file/requireCloudConfig';
@@ -62,6 +63,10 @@ const initialiseIpcHandlers: (ipcContext: IpcContext) => void = (
   );
 
   ipcMain.handle('read-cloud-config', async () => readCloudConfig());
+
+  ipcMain.handle('read-default-engine-config', async () =>
+    readDefaultEngineConfig()
+  );
 
   ipcMain.handle('read-recent-projects', async () => readRecentProjects());
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -10,7 +10,7 @@ import deleteProject from './handlers/file/deleteProject';
 import openExternalLink from './handlers/file/openLinkInExternalWindow';
 import openProject from './handlers/file/openProjectHandler';
 import retrieveProjectMetadata from './handlers/file/projectMetadataHandler';
-import readCloudCredentials from './handlers/file/readCloudCredentials';
+import readCloudConfig from './handlers/file/readCloudConfig';
 import readRecentProjects from './handlers/file/readRecentProjects';
 import requestMediaDialog from './handlers/file/requestMediaDialog';
 import requireCloudConfig from './handlers/file/requireCloudConfig';
@@ -61,7 +61,7 @@ const initialiseIpcHandlers: (ipcContext: IpcContext) => void = (
     retrieveProjectMetadata(project)
   );
 
-  ipcMain.handle('read-cloud-credentials', async () => readCloudCredentials());
+  ipcMain.handle('read-cloud-config', async () => readCloudConfig());
 
   ipcMain.handle('read-recent-projects', async () => readRecentProjects());
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -10,6 +10,7 @@ import deleteProject from './handlers/file/deleteProject';
 import openExternalLink from './handlers/file/openLinkInExternalWindow';
 import openProject from './handlers/file/openProjectHandler';
 import retrieveProjectMetadata from './handlers/file/projectMetadataHandler';
+import readCloudCredentials from './handlers/file/readCloudCredentials';
 import readRecentProjects from './handlers/file/readRecentProjects';
 import requestMediaDialog from './handlers/file/requestMediaDialog';
 import requireCloudConfig from './handlers/file/requireCloudConfig';
@@ -60,6 +61,8 @@ const initialiseIpcHandlers: (ipcContext: IpcContext) => void = (
     retrieveProjectMetadata(project)
   );
 
+  ipcMain.handle('read-cloud-credentials', async () => readCloudCredentials());
+
   ipcMain.handle('read-recent-projects', async () => readRecentProjects());
 
   ipcMain.handle('request-media-dialog', async () =>
@@ -82,8 +85,10 @@ const initialiseIpcHandlers: (ipcContext: IpcContext) => void = (
     saveProject(ipcContext, project)
   );
 
-  ipcMain.handle('store-cloud-credentials', async (_event, data) =>
-    storeCloudCredentials(data)
+  ipcMain.handle(
+    'store-cloud-credentials',
+    async (_event, defaultEngine, engineConfigs) =>
+      storeCloudCredentials(defaultEngine, engineConfigs)
   );
 
   ipcMain.handle('write-recent-projects', async (_event, recentProjects) =>

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -13,7 +13,7 @@ contextBridge.exposeInMainWorld('electron', {
   retrieveProjectMetadata: (project) =>
     ipcRenderer.invoke('retrieve-project-metadata', project),
 
-  readCloudCredentials: () => ipcRenderer.invoke('read-cloud-credentials'),
+  readCloudConfig: () => ipcRenderer.invoke('read-cloud-config'),
 
   readRecentProjects: () => ipcRenderer.invoke('read-recent-projects'),
 

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -15,6 +15,9 @@ contextBridge.exposeInMainWorld('electron', {
 
   readCloudConfig: () => ipcRenderer.invoke('read-cloud-config'),
 
+  readDefaultEngineConfig: () =>
+    ipcRenderer.invoke('read-default-engine-config'),
+
   readRecentProjects: () => ipcRenderer.invoke('read-recent-projects'),
 
   requestMediaDialog: () => ipcRenderer.invoke('request-media-dialog'),

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -13,6 +13,8 @@ contextBridge.exposeInMainWorld('electron', {
   retrieveProjectMetadata: (project) =>
     ipcRenderer.invoke('retrieve-project-metadata', project),
 
+  readCloudCredentials: () => ipcRenderer.invoke('read-cloud-credentials'),
+
   readRecentProjects: () => ipcRenderer.invoke('read-recent-projects'),
 
   requestMediaDialog: () => ipcRenderer.invoke('request-media-dialog'),
@@ -26,8 +28,8 @@ contextBridge.exposeInMainWorld('electron', {
 
   saveProject: (project) => ipcRenderer.invoke('save-project', project),
 
-  storeCloudCredentials: (data) =>
-    ipcRenderer.invoke('store-cloud-credentials', data),
+  storeCloudCredentials: (defaultEngine, engineConfigs) =>
+    ipcRenderer.invoke('store-cloud-credentials', defaultEngine, engineConfigs),
 
   writeRecentProjects: (recentProjects) =>
     ipcRenderer.invoke('write-recent-projects', recentProjects),

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -55,7 +55,7 @@ export const getThumbnailPath: (projectId: string) => string = (projectId) =>
   path.join(getProjectDataDir(projectId), 'thumbnail.png');
 
 export const appCloudConfigPath: () => string = () =>
-  path.join(appDataStoragePath(), 'cloudConfig.txt');
+  path.join(appDataStoragePath(), 'cloudConfig.json');
 
 export const fileOrDirExists: (filePath: string) => boolean = (filePath) =>
   statSync(filePath, { throwIfNoEntry: false }) !== undefined;

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -87,7 +87,6 @@ function AppContents() {
               closeModal={closeUpdateTranscriptionAPIKey}
               nextView={null}
               projectName=""
-              textToDisplay={null}
             />
           </CustomModalInner>
         </CustomModal>

--- a/src/renderer/components/ProjectCreation/CloudConfigView.tsx
+++ b/src/renderer/components/ProjectCreation/CloudConfigView.tsx
@@ -55,10 +55,10 @@ const CloudConfigView = ({
   useEffect(() => {
     const configInfo = async () => {
       const engineConfig = await readDefaultEngineConfig();
-      console.log(engineConfig);
       if (engineConfig !== null) {
         setText('Update API Key');
         setOriginalApiKey(engineConfig);
+        setAwaitingApiKey(false);
       }
     };
     configInfo().catch((err) => {
@@ -67,14 +67,11 @@ const CloudConfigView = ({
   }, []);
 
   const saveCloudCredentials: () => void = () => {
-    if (apiKey === null) {
-      return;
+    if (apiKey !== null) {
+      setApiKey(apiKey.trim());
+      // hard coded to be assembly ai
+      storeCloudCredentials(TranscriptionEngine.ASSEMBLYAI, apiKey);
     }
-
-    setApiKey(apiKey.trim());
-    console.log(apiKey);
-    // hard coded to be assembly ai
-    storeCloudCredentials(TranscriptionEngine.ASSEMBLYAI, apiKey);
     if (nextView === null) {
       closeModal();
     } else {

--- a/src/renderer/components/ProjectCreation/CloudConfigView.tsx
+++ b/src/renderer/components/ProjectCreation/CloudConfigView.tsx
@@ -120,7 +120,7 @@ const CloudConfigView = ({
   ]);
 
   return (
-    <Container sx={{ height: { xs: 500 } }}>
+    <Container position="relative" height="500px">
       <CustomRowStack justifyContent="space-between">
         <Typography
           overflow="hidden"
@@ -137,7 +137,7 @@ const CloudConfigView = ({
           <CloseIcon />
         </IconButton>
       </CustomRowStack>
-      <CustomColumnStack justifyContent="space-between" sx={{ height: '83%' }}>
+      <CustomColumnStack justifyContent="space-between" sx={{ height: '50%' }}>
         <CustomStack justifyContent="space-between">
           <CustomStack>
             <Typography
@@ -173,11 +173,16 @@ const CloudConfigView = ({
             />
           </CustomStack>
         </CustomColumnStack>
-        <CustomRowStack justifyContent="space-between" sx={{ gap: '32px' }}>
-          {cancelButton}
-          {saveButton}
-        </CustomRowStack>
       </CustomColumnStack>
+      <CustomRowStack
+        position="absolute"
+        bottom="0px"
+        justifyContent="space-between"
+        sx={{ gap: '32px' }}
+      >
+        {cancelButton}
+        {saveButton}
+      </CustomRowStack>
     </Container>
   );
 };

--- a/src/renderer/components/ProjectCreation/CloudConfigView.tsx
+++ b/src/renderer/components/ProjectCreation/CloudConfigView.tsx
@@ -11,6 +11,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import colors from 'renderer/colors';
 import { useState } from 'react';
 import useKeypress from 'renderer/utils/hooks';
+import { AssemblyAiConfig, TranscriptionEngine } from 'sharedTypes';
 import { PrimaryButton, SecondaryButton } from '../Blocks/Buttons';
 import ipc from '../../ipc';
 
@@ -48,7 +49,11 @@ const CloudConfigView = ({
 
   const saveCloudCredentials: () => void = () => {
     setApiKey(apiKey.trim());
-    storeCloudCredentials(apiKey);
+    // hard coded to be assembly ai
+    const assemblyAiConfig: AssemblyAiConfig = {
+      apiKey,
+    };
+    storeCloudCredentials(TranscriptionEngine.ASSEMBLYAI, assemblyAiConfig);
     if (nextView === null) {
       closeModal();
     } else {

--- a/src/renderer/components/ProjectCreation/CloudConfigView.tsx
+++ b/src/renderer/components/ProjectCreation/CloudConfigView.tsx
@@ -9,11 +9,14 @@ import {
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import colors from 'renderer/colors';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import useKeypress from 'renderer/utils/hooks';
-import { AssemblyAiConfig, TranscriptionEngine } from 'sharedTypes';
+import { TranscriptionEngine } from '../../../sharedTypes';
+import { getDefaultEngineConfig } from '../../../sharedUtils';
 import { PrimaryButton, SecondaryButton } from '../Blocks/Buttons';
 import ipc from '../../ipc';
+
+const { requireCloudConfig, readCloudConfig } = ipc;
 
 const { openExternalLink, storeCloudCredentials } = ipc;
 interface Props {
@@ -21,7 +24,6 @@ interface Props {
   closeModal: () => void;
   nextView: (() => void) | null;
   projectName: string;
-  textToDisplay: string | null;
 }
 
 const CustomStack = styled(Stack)({ width: '100%' });
@@ -37,23 +39,24 @@ const Container = styled(Box)({
   backgroundColor: colors.grey[700],
 });
 
+const defaultText =
+  "This is your first time using cloud transcription. To get started, you'll need to provide an API key and client secret for Google Cloud Speech-to-Text";
+
 const CloudConfigView = ({
   prevView,
   closeModal,
   nextView,
   projectName,
-  textToDisplay,
 }: Props) => {
   const [isAwaitingApiKey, setAwaitingApiKey] = useState<boolean>(true);
   const [apiKey, setApiKey] = useState<string>('');
+  const [text, setText] = useState<string>(defaultText);
 
   const saveCloudCredentials: () => void = () => {
     setApiKey(apiKey.trim());
+    console.log(apiKey);
     // hard coded to be assembly ai
-    const assemblyAiConfig: AssemblyAiConfig = {
-      apiKey,
-    };
-    storeCloudCredentials(TranscriptionEngine.ASSEMBLYAI, assemblyAiConfig);
+    storeCloudCredentials(TranscriptionEngine.ASSEMBLYAI, apiKey);
     if (nextView === null) {
       closeModal();
     } else {
@@ -96,10 +99,33 @@ const CloudConfigView = ({
     );
   };
 
-  const defaultText =
-    'This is your first time using the cloud transcription method. To get started you’ll need to provide an API key and client secret for AssemblyAI';
-
-  const text = textToDisplay ?? defaultText;
+  useEffect(() => {
+    const updateText = async () => {
+      const configNull = await requireCloudConfig();
+      console.log(configNull);
+      if (configNull) {
+        console.log('hello');
+        const cloudConfig = await readCloudConfig();
+        if (cloudConfig !== null) {
+          const engineConfig = await getDefaultEngineConfig(cloudConfig);
+          if (engineConfig != null) {
+            setText('Update API Key');
+            setApiKey(engineConfig);
+          }
+        }
+      }
+    };
+    updateText()
+      // .then((apiKeyExists) => {
+      //   if (apiKeyExists) {
+      //     // setText('Update API Key');
+      //   }
+      //   return apiKeyExists;
+      // })
+      .catch((err) => {
+        console.log(err);
+      });
+  }, []);
 
   useKeypress(saveCloudCredentials, !isAwaitingApiKey, [
     'Enter',

--- a/src/renderer/components/ProjectCreation/CloudConfigView.tsx
+++ b/src/renderer/components/ProjectCreation/CloudConfigView.tsx
@@ -39,7 +39,7 @@ const Container = styled(Box)({
 });
 
 const defaultText =
-  "This is your first time using cloud transcription. To get started, you'll need to provide an API key and client secret for Google Cloud Speech-to-Text";
+  "This is your first time using cloud transcription. To get started, you'll need to provide an API key and client secret for AssemblyAI";
 
 const CloudConfigView = ({
   prevView,

--- a/src/renderer/components/ProjectCreation/ImportMediaView.tsx
+++ b/src/renderer/components/ProjectCreation/ImportMediaView.tsx
@@ -91,7 +91,7 @@ const ImportMediaView = ({ prevView, closeModal, nextView }: Props) => {
   );
 
   return (
-    <Container sx={{ height: { xs: 500 } }}>
+    <Container position="relative" sx={{ height: { xs: 500 } }}>
       <CustomColumnStack
         alignItems="flex-start"
         justifyContent="space-between"
@@ -131,7 +131,12 @@ const ImportMediaView = ({ prevView, closeModal, nextView }: Props) => {
           removeMediaFromImport={removeMediaFromImport}
         />
       </CustomColumnStack>
-      <CustomRowStack justifyContent="space-between" sx={{ gap: '32px' }}>
+      <CustomRowStack
+        position="absolute"
+        bottom="0px"
+        justifyContent="space-between"
+        sx={{ gap: '32px' }}
+      >
         {cancelButton}
         {transcribeButton}
       </CustomRowStack>

--- a/src/renderer/components/ProjectCreation/ModalContainer.tsx
+++ b/src/renderer/components/ProjectCreation/ModalContainer.tsx
@@ -119,7 +119,6 @@ const ModalContainer = ({ isOpen, closeModal }: Props) => {
             closeModal={showCancelProject}
             nextView={nextView}
             projectName={projectName}
-            textToDisplay={null}
           />
         );
       case ImportMediaView:

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -37,6 +37,8 @@ declare global {
 
       readCloudConfig: () => Promise<CloudConfig>;
 
+      readDefaultEngineConfig: () => Promise<EngineConfig>;
+
       readRecentProjects: () => Promise<RecentProject[]>;
 
       requestMediaDialog: () => Promise<string | null>;

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -14,6 +14,7 @@ import {
   ProjectIdAndFilePath,
   TranscriptionEngine,
   EngineConfig,
+  CloudConfig,
 } from '../sharedTypes';
 
 declare global {
@@ -34,7 +35,7 @@ declare global {
         project: Pick<RuntimeProject, 'projectFilePath' | 'mediaFilePath'>
       ) => Promise<ProjectMetadata>;
 
-      readCloudCredentials: () => Promise<CloudConfig>;
+      readCloudConfig: () => Promise<CloudConfig>;
 
       readRecentProjects: () => Promise<RecentProject[]>;
 

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -4,7 +4,6 @@
 
 import { BrowserWindow, IpcRendererEvent } from 'electron';
 import { SaveDialogSelections } from 'main/handlers/helpers/saveDialog';
-import { TranscriptionEngine } from 'main/handlers/helpers/transcribeTypes';
 import { JSONTranscription } from 'main/types';
 import {
   OperatingSystems,
@@ -13,6 +12,8 @@ import {
   RecentProject,
   Transcription,
   ProjectIdAndFilePath,
+  TranscriptionEngine,
+  EngineConfig,
 } from '../sharedTypes';
 
 declare global {
@@ -33,6 +34,8 @@ declare global {
         project: Pick<RuntimeProject, 'projectFilePath' | 'mediaFilePath'>
       ) => Promise<ProjectMetadata>;
 
+      readCloudCredentials: () => Promise<CloudConfig>;
+
       readRecentProjects: () => Promise<RecentProject[]>;
 
       requestMediaDialog: () => Promise<string | null>;
@@ -48,15 +51,16 @@ declare global {
 
       saveProject: (project: RuntimeProject) => Promise<string>;
 
-      storeCloudCredentials: (data: string) => Promise<void>;
+      storeCloudCredentials: (
+        defaultEngine: TranscriptionEngine,
+        engineConfigs: EngineConfig
+      ) => Promise<void>;
 
       writeRecentProjects: (recentProjects: RecentProject[]) => Promise<void>;
 
       extractAudio: (project: RuntimeProject) => Promise<string>;
 
       exportProject: (project: RuntimeProject) => Promise<string>;
-
-      updateTranscriptionAPIKey: (project: RuntimeProject) => Promise<string>;
 
       extractThumbnail: (
         absolutePathToVideoFile: string,

--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -13,6 +13,7 @@ const mockIpc = {
   setUndoRedoEnabled: async () => null,
   setConfidenceLinesEnabled: async () => null,
   handleOsQuery: async () => null,
+  requireCloudConfig: () => false,
 };
 
 const ipc = window.electron ?? mockIpc;

--- a/src/sharedTypes.ts
+++ b/src/sharedTypes.ts
@@ -56,19 +56,16 @@ export interface TakeInfo {
 }
 
 export enum TranscriptionEngine {
-  DUMMY,
-  ASSEMBLYAI,
+  DUMMY = 'DUMMY',
+  ASSEMBLYAI = 'ASSEMBLYAI',
 }
 
-export type EngineConfig = AssemblyAiConfig | null;
-
-export interface AssemblyAiConfig {
-  apiKey: string;
-}
+export type EngineConfig = string | null;
 
 export interface CloudConfig {
   defaultEngine: TranscriptionEngine;
-  engineConfigs: Map<string, EngineConfig>;
+  ASSEMBLYAI: EngineConfig;
+  DUMMY: EngineConfig;
 }
 
 export interface Word {

--- a/src/sharedTypes.ts
+++ b/src/sharedTypes.ts
@@ -55,6 +55,22 @@ export interface TakeInfo {
   takeIndex: number;
 }
 
+export enum TranscriptionEngine {
+  DUMMY,
+  ASSEMBLYAI,
+}
+
+export type EngineConfig = AssemblyAiConfig | null;
+
+export interface AssemblyAiConfig {
+  apiKey: string;
+}
+
+export interface CloudConfig {
+  defaultEngine: TranscriptionEngine;
+  engineConfigs: Map<string, EngineConfig>;
+}
+
 export interface Word {
   // Text content of the word
   word: string;

--- a/src/sharedUtils.ts
+++ b/src/sharedUtils.ts
@@ -6,6 +6,9 @@ import {
   MapCallback,
   IndexRange,
   TakeGroup,
+  TranscriptionEngine,
+  EngineConfig,
+  CloudConfig,
 } from './sharedTypes';
 
 // Round a number in seconds to milliseconds - solves a lot of floating point errors
@@ -45,6 +48,19 @@ export const makeRecentProject: (
 
 export const bufferedWordDuration: (word: Word) => number = (word) =>
   word.bufferDurationBefore + word.duration + word.bufferDurationAfter;
+
+export const getDefaultEngineConfig = (
+  cloudConfig: CloudConfig
+): EngineConfig => {
+  switch (cloudConfig.defaultEngine) {
+    case TranscriptionEngine.ASSEMBLYAI: {
+      return cloudConfig.ASSEMBLYAI;
+    }
+    default: {
+      return cloudConfig.DUMMY;
+    }
+  }
+};
 
 /**
  * Maps the values of a list using a given map function,

--- a/src/sharedUtils.ts
+++ b/src/sharedUtils.ts
@@ -49,7 +49,7 @@ export const makeRecentProject: (
 export const bufferedWordDuration: (word: Word) => number = (word) =>
   word.bufferDurationBefore + word.duration + word.bufferDurationAfter;
 
-export const getDefaultEngineConfig = (
+export const findDefaultEngineConfig = (
   cloudConfig: CloudConfig
 ): EngineConfig => {
   switch (cloudConfig.defaultEngine) {


### PR DESCRIPTION
# Cloud Config File

## Description
Implements the ability to enter, store and retrieve API keys nad a default TranscriptionEngine. Configs are stored in a JSON file in the appdata mlvet folder as "cloudConfig.json". 

The currently stored key is displayed in the CloudConfigView text box upon opening.
The text for the CloudConfigView information changes depending on whether it is the user's first time entering the API key.

## Why is this change needed?
Allows users to enter their custom API key, use it to transcribe and have it saved for multiple sessions.

## OS

- [x] Windows
- [x] Mac
- [ ] Linux



