### PR TITLE
Editor performance improvements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,9 @@ module.exports = {
     'import/no-unresolved': 'error',
     // Since React 17 and typescript 4.1 you can safely disable the rule
     'react/react-in-jsx-scope': 'off',
+    // Prop spreading helps us greatly simplify the prop drilling nightmare that is
+    // transcription rendering
+    'react/jsx-props-no-spreading': 'off',
   },
   parserOptions: {
     ecmaVersion: 2020,

--- a/src/renderer/components/Editor/PlaybackManager.tsx
+++ b/src/renderer/components/Editor/PlaybackManager.tsx
@@ -3,6 +3,7 @@ import {
   ReactElement,
   RefObject,
   SetStateAction,
+  useCallback,
   useEffect,
   useState,
 } from 'react';
@@ -41,10 +42,17 @@ const PlaybackManager = ({
   const [nowPlayingWordIndex, setNowPlayingWordIndex] = useState<number>(0);
 
   const play = () => videoPreviewControllerRef?.current?.play();
+
   const pause = () => videoPreviewControllerRef?.current?.pause();
-  const setPlaybackTime = (newPlaybackTime: number) =>
-    videoPreviewControllerRef?.current?.setPlaybackTime(newPlaybackTime);
+
+  const setPlaybackTime = useCallback(
+    (newPlaybackTime: number) =>
+      videoPreviewControllerRef?.current?.setPlaybackTime(newPlaybackTime),
+    [videoPreviewControllerRef]
+  );
+
   const seekForward = () => videoPreviewControllerRef?.current?.seekForward();
+
   const seekBack = () => videoPreviewControllerRef?.current?.seekBack();
 
   // TODO: Look into optimisations
@@ -67,17 +75,21 @@ const PlaybackManager = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [time, currentProject?.transcription]);
 
-  const seekToWord: (wordIndex: number) => void = (wordIndex) => {
-    if (currentProject !== null && currentProject?.transcription !== null) {
-      // Fixes some minor floating point errors that cause the previous word to be selected
-      // instead of the current one
-      const epsilon = 0.01;
+  const seekToWord: (wordIndex: number) => void = useCallback(
+    (wordIndex) => {
+      if (currentProject !== null && currentProject?.transcription !== null) {
+        // Fixes some minor floating point errors that cause the previous word to be selected
+        // instead of the current one
+        const epsilon = 0.01;
 
-      const newTime =
-        currentProject.transcription.words[wordIndex].outputStartTime + epsilon;
-      setPlaybackTime(newTime);
-    }
-  };
+        const newTime =
+          currentProject.transcription.words[wordIndex].outputStartTime +
+          epsilon;
+        setPlaybackTime(newTime);
+      }
+    },
+    [currentProject, setPlaybackTime]
+  );
 
   return children(
     time,

--- a/src/renderer/components/Editor/PlaybackManager.tsx
+++ b/src/renderer/components/Editor/PlaybackManager.tsx
@@ -5,9 +5,10 @@ import {
   SetStateAction,
   useCallback,
   useEffect,
+  useMemo,
   useState,
 } from 'react';
-import { RuntimeProject } from 'sharedTypes';
+import { RuntimeProject, Word } from 'sharedTypes';
 import { bufferedWordDuration, isInInactiveTake } from 'sharedUtils';
 import { VideoPreviewControllerRef } from '../VideoPreview/VideoPreviewController';
 
@@ -21,7 +22,6 @@ type ChildFunction = (
   pause: () => void,
   seekForward: () => void,
   seekBack: () => void,
-  seekToWord: (wordIndex: number) => void,
   setPlaybackTime: (newPlaybackTime: number) => void
 ) => ReactElement;
 
@@ -41,9 +41,15 @@ const PlaybackManager = ({
   const [isPlaying, setIsPlaying] = useState(false);
   const [nowPlayingWordIndex, setNowPlayingWordIndex] = useState<number>(0);
 
-  const play = () => videoPreviewControllerRef?.current?.play();
+  const play = useCallback(
+    () => videoPreviewControllerRef?.current?.play(),
+    [videoPreviewControllerRef]
+  );
 
-  const pause = () => videoPreviewControllerRef?.current?.pause();
+  const pause = useCallback(
+    () => videoPreviewControllerRef?.current?.pause(),
+    [videoPreviewControllerRef]
+  );
 
   const setPlaybackTime = useCallback(
     (newPlaybackTime: number) =>
@@ -51,9 +57,15 @@ const PlaybackManager = ({
     [videoPreviewControllerRef]
   );
 
-  const seekForward = () => videoPreviewControllerRef?.current?.seekForward();
+  const seekForward = useCallback(
+    () => videoPreviewControllerRef?.current?.seekForward(),
+    [videoPreviewControllerRef]
+  );
 
-  const seekBack = () => videoPreviewControllerRef?.current?.seekBack();
+  const seekBack = useCallback(
+    () => videoPreviewControllerRef?.current?.seekBack(),
+    [videoPreviewControllerRef]
+  );
 
   // TODO: Look into optimisations
   useEffect(() => {
@@ -75,34 +87,33 @@ const PlaybackManager = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [time, currentProject?.transcription]);
 
-  const seekToWord: (wordIndex: number) => void = useCallback(
-    (wordIndex) => {
-      if (currentProject !== null && currentProject?.transcription !== null) {
-        // Fixes some minor floating point errors that cause the previous word to be selected
-        // instead of the current one
-        const epsilon = 0.01;
-
-        const newTime =
-          currentProject.transcription.words[wordIndex].outputStartTime +
-          epsilon;
-        setPlaybackTime(newTime);
-      }
-    },
-    [currentProject, setPlaybackTime]
-  );
-
-  return children(
-    time,
-    setTime,
-    isPlaying,
-    setIsPlaying,
-    nowPlayingWordIndex,
-    play,
-    pause,
-    seekForward,
-    seekBack,
-    seekToWord,
-    setPlaybackTime
+  return useMemo(
+    () =>
+      children(
+        time,
+        setTime,
+        isPlaying,
+        setIsPlaying,
+        nowPlayingWordIndex,
+        play,
+        pause,
+        seekForward,
+        seekBack,
+        setPlaybackTime
+      ),
+    [
+      time,
+      setTime,
+      isPlaying,
+      setIsPlaying,
+      nowPlayingWordIndex,
+      play,
+      pause,
+      seekForward,
+      seekBack,
+      setPlaybackTime,
+      children,
+    ]
   );
 };
 

--- a/src/renderer/components/Editor/PlaybackManager.tsx
+++ b/src/renderer/components/Editor/PlaybackManager.tsx
@@ -1,4 +1,4 @@
-import {
+import React, {
   Dispatch,
   ReactElement,
   RefObject,
@@ -117,4 +117,4 @@ const PlaybackManager = ({
   );
 };
 
-export default PlaybackManager;
+export default React.memo(PlaybackManager);

--- a/src/renderer/components/Editor/PlaybackManager.tsx
+++ b/src/renderer/components/Editor/PlaybackManager.tsx
@@ -8,7 +8,7 @@ import {
   useMemo,
   useState,
 } from 'react';
-import { RuntimeProject, Word } from 'sharedTypes';
+import { RuntimeProject } from 'sharedTypes';
 import { bufferedWordDuration, isInInactiveTake } from 'sharedUtils';
 import { VideoPreviewControllerRef } from '../VideoPreview/VideoPreviewController';
 

--- a/src/renderer/components/Editor/ResizeManager.tsx
+++ b/src/renderer/components/Editor/ResizeManager.tsx
@@ -1,4 +1,4 @@
-import {
+import React, {
   Dispatch,
   ReactElement,
   RefObject,
@@ -141,4 +141,4 @@ const ResizeManager = ({
   );
 };
 
-export default ResizeManager;
+export default React.memo(ResizeManager);

--- a/src/renderer/components/Editor/ResizeSlider.tsx
+++ b/src/renderer/components/Editor/ResizeSlider.tsx
@@ -1,6 +1,6 @@
 import { Box, styled, colors, BoxProps } from '@mui/material';
 import { clamp } from 'main/timeUtils';
-import { DragEvent, useEffect, useRef } from 'react';
+import React, { useCallback, DragEvent, useEffect, useRef } from 'react';
 
 interface ResizeSliderProps extends BoxProps {
   targetWidth: number;
@@ -45,31 +45,46 @@ const ResizeSlider = ({
   const dragStartWidth = useRef(targetWidth);
   const dragStartPositionRef = useRef(0);
 
-  const onMouseMove = (e: { pageX: number }) => {
-    const dragDistance = e.pageX - dragStartPositionRef.current;
-    const newWidth = clamp(
+  const onMouseMove = useCallback(
+    (e: { pageX: number }) => {
+      const dragDistance = e.pageX - dragStartPositionRef.current;
+      const newWidth = clamp(
+        minTargetWidth,
+        dragStartWidth.current - dragDistance,
+        maxTargetWidth
+      );
+      setTargetWidth(newWidth);
+    },
+    [
+      dragStartPositionRef,
       minTargetWidth,
-      dragStartWidth.current - dragDistance,
-      maxTargetWidth
-    );
-    setTargetWidth(newWidth);
-  };
+      dragStartWidth,
+      maxTargetWidth,
+      setTargetWidth,
+    ]
+  );
 
-  const onMouseUp = () => {
+  const onMouseUp = useCallback(() => {
     dragStartPositionRef.current = 0;
     document.body.removeEventListener('mousemove', onMouseMove);
-  };
+  }, [dragStartPositionRef, onMouseMove]);
 
-  const onMouseDown = (e: { pageX: number }) => {
-    dragStartWidth.current = targetWidth;
-    dragStartPositionRef.current = e.pageX;
+  const onMouseDown = useCallback(
+    (e: { pageX: number }) => {
+      dragStartWidth.current = targetWidth;
+      dragStartPositionRef.current = e.pageX;
 
-    document.body.addEventListener('mousemove', onMouseMove);
-    document.body.addEventListener('mouseup', onMouseUp, { once: true });
-  };
+      document.body.addEventListener('mousemove', onMouseMove);
+      document.body.addEventListener('mouseup', onMouseUp, { once: true });
+    },
+    [dragStartWidth, dragStartPositionRef, onMouseMove, onMouseUp, targetWidth]
+  );
 
   // Needed to avoid div 'forking' bug with weird cursor icon
-  const onDragStart = (e: DragEvent<HTMLDivElement>) => e.preventDefault();
+  const onDragStart = useCallback(
+    (e: DragEvent<HTMLDivElement>) => e.preventDefault(),
+    []
+  );
 
   // Cleanup for event listeners when components unmounts
   useEffect(() => {
@@ -87,4 +102,4 @@ const ResizeSlider = ({
   );
 };
 
-export default ResizeSlider;
+export default React.memo(ResizeSlider);

--- a/src/renderer/components/Editor/RestorePopover.tsx
+++ b/src/renderer/components/Editor/RestorePopover.tsx
@@ -5,7 +5,7 @@ import {
   styled,
   Typography,
 } from '@mui/material';
-import { RefObject } from 'react';
+import React, { RefObject } from 'react';
 import colors from 'renderer/colors';
 import useKeypress from 'renderer/utils/hooks';
 
@@ -74,4 +74,4 @@ const RestorePopover = ({
   );
 };
 
-export default RestorePopover;
+export default React.memo(RestorePopover);

--- a/src/renderer/components/Editor/TakeComponent.tsx
+++ b/src/renderer/components/Editor/TakeComponent.tsx
@@ -55,7 +55,7 @@ interface TakeComponentProps extends TakePassThroughProps {
   nowPlayingWordIndex: number | null;
   selectionSet: Set<number>;
   onWordMouseDown: WordMouseHandler;
-  onWordMouseMove: any;
+  onWordMouseMove: (wordIndex: number) => void;
   transcriptionIndex: number;
 }
 

--- a/src/renderer/components/Editor/TakeComponent.tsx
+++ b/src/renderer/components/Editor/TakeComponent.tsx
@@ -138,25 +138,30 @@ const TakeComponent = ({
         )}
         {isTakeGroupOpened || isActive ? (
           <>
-            {takeWords.map((word, index, words) => (
-              <WordOuterComponent
-                key={`word-outer-${word.originalIndex}-${word.pasteKey}`}
-                word={word}
-                prevWord={index > 0 ? words[index - 1] : null}
-                nextWord={index < words.length - 1 ? words[index + 1] : null}
-                index={transcriptionIndex + index}
-                mouse={mousePosition}
-                isPlaying={nowPlayingWordIndex === index}
-                isSelected={selectionSet.has(index)}
-                isPrevWordSelected={selectionSet.has(index - 1)}
-                isNextWordSelected={selectionSet.has(index + 1)}
-                onMouseDown={onWordMouseDown}
-                onMouseMove={onWordMouseMove}
-                isInInactiveTake={!isActive || !isTakeGroupOpened}
-                transcriptionLength={words.length}
-                {...passThroughProps}
-              />
-            ))}
+            {takeWords.map((word, index, words) => {
+              const wordIndex = transcriptionIndex + index;
+              return (
+                <WordOuterComponent
+                  key={`word-outer-${word.originalIndex}-${word.pasteKey}`}
+                  word={word}
+                  prevWord={wordIndex > 0 ? words[wordIndex - 1] : null}
+                  nextWord={
+                    wordIndex < words.length - 1 ? words[wordIndex + 1] : null
+                  }
+                  index={wordIndex}
+                  mouse={mousePosition}
+                  isPlaying={nowPlayingWordIndex === wordIndex}
+                  isSelected={selectionSet.has(wordIndex)}
+                  isPrevWordSelected={selectionSet.has(wordIndex - 1)}
+                  isNextWordSelected={selectionSet.has(wordIndex + 1)}
+                  onMouseDown={onWordMouseDown}
+                  onMouseMove={onWordMouseMove}
+                  isInInactiveTake={!isActive || !isTakeGroupOpened}
+                  transcriptionLength={words.length}
+                  {...passThroughProps}
+                />
+              );
+            })}
           </>
         ) : null}
       </TakeWrapper>

--- a/src/renderer/components/Editor/TakeComponent.tsx
+++ b/src/renderer/components/Editor/TakeComponent.tsx
@@ -35,7 +35,6 @@ interface TakeComponentProps {
   isTakeGroupOpened: boolean;
   setIsTakeGroupOpened: (isOpen: boolean) => void;
   transcription: Transcription;
-  seekToWord: (wordIndex: number) => void;
   dragState: DragState; // current state of ANY drag (null if no word being dragged)
   mousePosition: MousePosition | null;
   mouseThrottled: MousePosition | null;
@@ -62,7 +61,6 @@ const TakeComponent = ({
   isTakeGroupOpened,
   setIsTakeGroupOpened,
   transcription,
-  seekToWord,
   dragState,
   mousePosition,
   dropBeforeIndex,
@@ -152,7 +150,6 @@ const TakeComponent = ({
                 word={word}
                 index={transcriptionIndex + index}
                 transcription={transcription}
-                seekToWord={seekToWord}
                 dragState={dragState}
                 mouse={mousePosition}
                 mouseThrottled={mouseThrottled}
@@ -160,8 +157,10 @@ const TakeComponent = ({
                 setDropBeforeIndex={setDropBeforeIndex}
                 cancelDrag={cancelDrag}
                 submitWordEdit={submitWordEdit}
-                nowPlayingWordIndex={nowPlayingWordIndex}
-                selectionSet={selectionSet}
+                isPlaying={nowPlayingWordIndex === index}
+                isSelected={selectionSet.has(index)}
+                isPrevWordSelected={selectionSet.has(index - 1)}
+                isNextWordSelected={selectionSet.has(index + 1)}
                 otherSelectionSets={otherSelectionSets}
                 onWordMouseDown={onWordMouseDown}
                 onWordMouseMove={onWordMouseMove}

--- a/src/renderer/components/Editor/TakeComponent.tsx
+++ b/src/renderer/components/Editor/TakeComponent.tsx
@@ -52,6 +52,7 @@ interface TakeComponentProps {
   transcriptionIndex: number;
   popoverWidth: number;
   transcriptionBlockRef: RefObject<HTMLElement>;
+  setPlaybackTime: (time: number) => void;
 }
 
 const TakeComponent = ({
@@ -78,6 +79,7 @@ const TakeComponent = ({
   transcriptionIndex,
   popoverWidth,
   transcriptionBlockRef,
+  setPlaybackTime,
 }: TakeComponentProps) => {
   const dispatch = useDispatch();
 
@@ -169,6 +171,7 @@ const TakeComponent = ({
                 isInInactiveTake={!isActive || !isTakeGroupOpened}
                 popoverWidth={popoverWidth}
                 transcriptionBlockRef={transcriptionBlockRef}
+                setPlaybackTime={setPlaybackTime}
               />
             ))}
           </>

--- a/src/renderer/components/Editor/TakeComponent.tsx
+++ b/src/renderer/components/Editor/TakeComponent.tsx
@@ -4,8 +4,9 @@ import { MousePosition } from '@react-hook/mouse-position';
 import { useDispatch } from 'react-redux';
 import { selectTake } from 'renderer/store/takeGroups/actions';
 import { TakeInfo, Transcription, Word } from 'sharedTypes';
-import { RefObject, useMemo } from 'react';
+import React, { RefObject, useCallback, useMemo } from 'react';
 import { ClientId } from 'collabTypes/collabShadowTypes';
+import { EditWordState } from 'renderer/store/sharedHelpers';
 import { DragState, WordMouseHandler } from './WordDragManager';
 import WordOuterComponent from './WordOuterComponent';
 
@@ -28,31 +29,34 @@ const makeTakeWrapper = (isTakeGroupOpened: boolean, isActive: boolean) =>
     },
   });
 
-interface TakeComponentProps {
+interface TakePassThroughProps {
+  transcription: Transcription;
+  dragState: DragState; // current state of ANY drag (null if no word being dragged)
+  dropBeforeIndex: number | null;
+  setDropBeforeIndex: (index: number) => void;
+  cancelDrag: () => void;
+  submitWordEdit: () => void;
+  popoverWidth: number;
+  transcriptionBlockRef: RefObject<HTMLElement>;
+  setPlaybackTime: (time: number) => void;
+  otherSelectionSets: Record<ClientId, Set<number>>;
+  isWordBeingDragged: (wordIndex: number) => boolean;
+  mouseThrottled: MousePosition | null;
+  editWord: EditWordState;
+}
+
+interface TakeComponentProps extends TakePassThroughProps {
   takeWords: Word[];
   takeIndex: number;
   isActive: boolean;
   isTakeGroupOpened: boolean;
   setIsTakeGroupOpened: (isOpen: boolean) => void;
-  transcription: Transcription;
-  dragState: DragState; // current state of ANY drag (null if no word being dragged)
   mousePosition: MousePosition | null;
-  mouseThrottled: MousePosition | null;
-  dropBeforeIndex: number | null;
-  setDropBeforeIndex: (index: number) => void;
-  cancelDrag: () => void;
-  submitWordEdit: () => void;
   nowPlayingWordIndex: number | null;
   selectionSet: Set<number>;
-  otherSelectionSets: Record<ClientId, Set<number>>;
   onWordMouseDown: WordMouseHandler;
   onWordMouseMove: any;
-  isWordBeingDragged: (wordIndex: number) => boolean;
-  editWord: any;
   transcriptionIndex: number;
-  popoverWidth: number;
-  transcriptionBlockRef: RefObject<HTMLElement>;
-  setPlaybackTime: (time: number) => void;
 }
 
 const TakeComponent = ({
@@ -61,45 +65,33 @@ const TakeComponent = ({
   isActive,
   isTakeGroupOpened,
   setIsTakeGroupOpened,
-  transcription,
-  dragState,
   mousePosition,
-  dropBeforeIndex,
-  setDropBeforeIndex,
-  cancelDrag,
-  submitWordEdit,
   nowPlayingWordIndex,
   selectionSet,
-  otherSelectionSets,
   onWordMouseDown,
   onWordMouseMove,
-  isWordBeingDragged,
-  mouseThrottled,
-  editWord,
   transcriptionIndex,
-  popoverWidth,
-  transcriptionBlockRef,
-  setPlaybackTime,
+  ...passThroughProps
 }: TakeComponentProps) => {
   const dispatch = useDispatch();
 
-  const onSelectTake = () => {
+  const onSelectTake = useCallback(() => {
     dispatch(selectTake(takeWords[0].takeInfo as TakeInfo));
     setIsTakeGroupOpened(false);
-  };
+  }, [dispatch, takeWords, setIsTakeGroupOpened]);
 
   const TakeWrapper = useMemo(
     () => makeTakeWrapper(isTakeGroupOpened, isActive),
     [isTakeGroupOpened, isActive]
   );
 
-  const onClick = () => {
+  const onClick = useCallback(() => {
     if (isActive && !isTakeGroupOpened) {
       setIsTakeGroupOpened(true);
     } else {
       onSelectTake();
     }
-  };
+  }, [isActive, isTakeGroupOpened, setIsTakeGroupOpened, onSelectTake]);
 
   return (
     <>
@@ -146,32 +138,23 @@ const TakeComponent = ({
         )}
         {isTakeGroupOpened || isActive ? (
           <>
-            {takeWords.map((word, index) => (
+            {takeWords.map((word, index, words) => (
               <WordOuterComponent
                 key={`word-outer-${word.originalIndex}-${word.pasteKey}`}
                 word={word}
+                prevWord={index > 0 ? words[index - 1] : null}
+                nextWord={index < words.length - 1 ? words[index + 1] : null}
                 index={transcriptionIndex + index}
-                transcription={transcription}
-                dragState={dragState}
                 mouse={mousePosition}
-                mouseThrottled={mouseThrottled}
-                dropBeforeIndex={dropBeforeIndex}
-                setDropBeforeIndex={setDropBeforeIndex}
-                cancelDrag={cancelDrag}
-                submitWordEdit={submitWordEdit}
                 isPlaying={nowPlayingWordIndex === index}
                 isSelected={selectionSet.has(index)}
                 isPrevWordSelected={selectionSet.has(index - 1)}
                 isNextWordSelected={selectionSet.has(index + 1)}
-                otherSelectionSets={otherSelectionSets}
-                onWordMouseDown={onWordMouseDown}
-                onWordMouseMove={onWordMouseMove}
-                isWordBeingDragged={isWordBeingDragged}
-                editWord={editWord}
+                onMouseDown={onWordMouseDown}
+                onMouseMove={onWordMouseMove}
                 isInInactiveTake={!isActive || !isTakeGroupOpened}
-                popoverWidth={popoverWidth}
-                transcriptionBlockRef={transcriptionBlockRef}
-                setPlaybackTime={setPlaybackTime}
+                transcriptionLength={words.length}
+                {...passThroughProps}
               />
             ))}
           </>
@@ -181,4 +164,4 @@ const TakeComponent = ({
   );
 };
 
-export default TakeComponent;
+export default React.memo(TakeComponent);

--- a/src/renderer/components/Editor/TakeGroupComponent.tsx
+++ b/src/renderer/components/Editor/TakeGroupComponent.tsx
@@ -91,6 +91,8 @@ const TakeGroupComponent = ({
         .map((take) => take.length)
         .reduce((acc, curr) => acc + curr, 0);
 
+    console.log(takeWords, takeIndex, chunkIndex, transcriptionIndex);
+
     return (
       <TakeComponent
         key={`take-${takeGroup.id}-${takeIndex}`}

--- a/src/renderer/components/Editor/TakeGroupComponent.tsx
+++ b/src/renderer/components/Editor/TakeGroupComponent.tsx
@@ -33,7 +33,7 @@ interface TakeGroupComponentProps extends TranscriptionPassThroughProps {
   takeGroup: TakeGroup;
   chunkIndex: number;
   onWordMouseDown: WordMouseHandler;
-  onWordMouseMove: any;
+  onWordMouseMove: (wordIndex: number) => void;
   mousePosition: MousePosition | null;
   nowPlayingWordIndex: number | null;
   selectionSet: Set<any>;

--- a/src/renderer/components/Editor/TakeGroupComponent.tsx
+++ b/src/renderer/components/Editor/TakeGroupComponent.tsx
@@ -22,12 +22,12 @@ interface TakeGroupComponentProps {
   editWord: any;
   nowPlayingWordIndex: number | null;
   transcription: Transcription;
-  seekToWord: (wordIndex: number) => void;
   submitWordEdit: () => void;
   selectionSet: Set<any>;
   otherSelectionSets: Record<ClientId, Set<number>>;
   popoverWidth: number;
   transcriptionBlockRef: RefObject<HTMLElement>;
+  setPlaybackTime: (time: number) => void;
 }
 
 const TakeGroupComponent = ({
@@ -45,12 +45,12 @@ const TakeGroupComponent = ({
   editWord,
   nowPlayingWordIndex,
   transcription,
-  seekToWord,
   submitWordEdit,
   selectionSet,
   otherSelectionSets,
   popoverWidth,
   transcriptionBlockRef,
+  setPlaybackTime,
 }: TakeGroupComponentProps) => {
   const [isTakeGroupOpened, setIsTakeGroupOpened] = useState(false);
 
@@ -111,13 +111,13 @@ const TakeGroupComponent = ({
         editWord={editWord}
         nowPlayingWordIndex={nowPlayingWordIndex}
         transcription={transcription}
-        seekToWord={seekToWord}
         submitWordEdit={submitWordEdit}
         selectionSet={selectionSet}
         otherSelectionSets={otherSelectionSets}
         transcriptionIndex={transcriptionIndex}
         popoverWidth={popoverWidth}
         transcriptionBlockRef={transcriptionBlockRef}
+        setPlaybackTime={setPlaybackTime}
       />
     );
   });

--- a/src/renderer/components/Editor/TakeGroupComponent.tsx
+++ b/src/renderer/components/Editor/TakeGroupComponent.tsx
@@ -2,32 +2,42 @@
 
 import { MousePosition } from '@react-hook/mouse-position';
 import { ClientId } from 'collabTypes/collabShadowTypes';
-import { Dispatch, RefObject, SetStateAction, useMemo, useState } from 'react';
+import React, {
+  Dispatch,
+  RefObject,
+  SetStateAction,
+  useMemo,
+  useState,
+} from 'react';
+import { EditWordState } from 'renderer/store/sharedHelpers';
 import { TakeGroup, Transcription, Word } from 'sharedTypes';
 import TakeComponent from './TakeComponent';
-import { WordMouseHandler, DragState } from './WordDragManager';
+import { DragState, WordMouseHandler } from './WordDragManager';
 
-interface TakeGroupComponentProps {
-  takeGroup: TakeGroup;
-  chunkIndex: number;
-  onWordMouseDown: WordMouseHandler;
-  onWordMouseMove: any;
+export interface TranscriptionPassThroughProps {
   dragState: DragState;
   isWordBeingDragged: (wordIndex: number) => boolean;
-  mousePosition: MousePosition | null;
   mouseThrottled: MousePosition | null;
   dropBeforeIndex: number | null;
   setDropBeforeIndex: Dispatch<SetStateAction<number | null>>;
   cancelDrag: () => void;
-  editWord: any;
-  nowPlayingWordIndex: number | null;
-  transcription: Transcription;
+  editWord: EditWordState;
   submitWordEdit: () => void;
-  selectionSet: Set<any>;
   otherSelectionSets: Record<ClientId, Set<number>>;
   popoverWidth: number;
   transcriptionBlockRef: RefObject<HTMLElement>;
   setPlaybackTime: (time: number) => void;
+}
+
+interface TakeGroupComponentProps extends TranscriptionPassThroughProps {
+  takeGroup: TakeGroup;
+  chunkIndex: number;
+  onWordMouseDown: WordMouseHandler;
+  onWordMouseMove: any;
+  mousePosition: MousePosition | null;
+  nowPlayingWordIndex: number | null;
+  selectionSet: Set<any>;
+  transcription: Transcription;
 }
 
 const TakeGroupComponent = ({
@@ -35,22 +45,12 @@ const TakeGroupComponent = ({
   chunkIndex,
   onWordMouseDown,
   onWordMouseMove,
-  dragState,
   isWordBeingDragged,
   mousePosition,
-  mouseThrottled,
-  dropBeforeIndex,
-  setDropBeforeIndex,
-  cancelDrag,
-  editWord,
   nowPlayingWordIndex,
-  transcription,
-  submitWordEdit,
   selectionSet,
-  otherSelectionSets,
-  popoverWidth,
-  transcriptionBlockRef,
-  setPlaybackTime,
+  transcription,
+  ...passThroughProps
 }: TakeGroupComponentProps) => {
   const [isTakeGroupOpened, setIsTakeGroupOpened] = useState(false);
 
@@ -101,23 +101,13 @@ const TakeGroupComponent = ({
         setIsTakeGroupOpened={setIsTakeGroupOpened}
         onWordMouseDown={onWordMouseDown}
         onWordMouseMove={onWordMouseMove}
-        dragState={dragState}
         isWordBeingDragged={isWordBeingDragged}
         mousePosition={mousePosition}
-        mouseThrottled={mouseThrottled}
-        dropBeforeIndex={dropBeforeIndex}
-        setDropBeforeIndex={setDropBeforeIndex}
-        cancelDrag={cancelDrag}
-        editWord={editWord}
         nowPlayingWordIndex={nowPlayingWordIndex}
         transcription={transcription}
-        submitWordEdit={submitWordEdit}
         selectionSet={selectionSet}
-        otherSelectionSets={otherSelectionSets}
         transcriptionIndex={transcriptionIndex}
-        popoverWidth={popoverWidth}
-        transcriptionBlockRef={transcriptionBlockRef}
-        setPlaybackTime={setPlaybackTime}
+        {...passThroughProps}
       />
     );
   });
@@ -134,4 +124,4 @@ const TakeGroupComponent = ({
   );
 };
 
-export default TakeGroupComponent;
+export default React.memo(TakeGroupComponent);

--- a/src/renderer/components/Editor/TranscriptionBlock.tsx
+++ b/src/renderer/components/Editor/TranscriptionBlock.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { Box } from '@mui/material';
-import { useCallback, useMemo, useRef } from 'react';
+import React, { Profiler, useCallback, useMemo, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { TakeGroup, Transcription, Word } from 'sharedTypes';
 import dispatchOp from 'renderer/store/dispatchOp';
@@ -133,71 +133,73 @@ const TranscriptionBlock = ({
   );
 
   return (
-    <WordDragManager clearSelection={clearSelection}>
-      {(
-        onWordMouseDown,
-        onWordMouseMove,
-        dragState,
-        isWordBeingDragged,
-        mouse,
-        mouseThrottled,
-        dropBeforeIndex,
-        setDropBeforeIndex,
-        cancelDrag
-      ) => {
-        return (
-          <TranscriptionBox id="transcription-content" ref={blockRef}>
-            {mapWithAccumulator(
-              transcriptionChunks,
-              (chunk, _, acc) => {
-                return {
-                  item: (
-                    <TranscriptionChunk
-                      key={
-                        isTakeGroup(chunk)
-                          ? `take-group-chunk-${(chunk as TakeGroup).id}`
-                          : `word-chunk-${(chunk as Word).originalIndex}-${
-                              (chunk as Word).pasteKey
-                            }`
-                      }
-                      chunk={chunk}
-                      chunkIndex={acc}
-                      onWordMouseDown={onWordMouseDown}
-                      onWordMouseMove={onWordMouseMove}
-                      dragState={dragState}
-                      isWordBeingDragged={isWordBeingDragged}
-                      mousePosition={mouse}
-                      mouseThrottled={mouseThrottled}
-                      dropBeforeIndex={dropBeforeIndex}
-                      setDropBeforeIndex={setDropBeforeIndex}
-                      cancelDrag={cancelDrag}
-                      editWord={editWord}
-                      nowPlayingWordIndex={nowPlayingWordIndex}
-                      transcription={transcription}
-                      submitWordEdit={submitWordEdit}
-                      selectionSet={ownSelectionSet}
-                      otherSelectionSets={otherSelectionSets}
-                      popoverWidth={blockWidth - 194}
-                      transcriptionBlockRef={blockRef}
-                      setPlaybackTime={setPlaybackTime}
-                    />
-                  ),
-                  acc: isTakeGroup(chunk)
-                    ? acc +
-                      getTakeGroupLength(
-                        chunk as TakeGroup,
-                        transcription.words
-                      )
-                    : acc + 1,
-                };
-              },
-              0
-            )}
-          </TranscriptionBox>
-        );
-      }}
-    </WordDragManager>
+    <Profiler id="block" onRender={console.log}>
+      <WordDragManager clearSelection={clearSelection}>
+        {(
+          onWordMouseDown,
+          onWordMouseMove,
+          dragState,
+          isWordBeingDragged,
+          mouse,
+          mouseThrottled,
+          dropBeforeIndex,
+          setDropBeforeIndex,
+          cancelDrag
+        ) => {
+          return (
+            <TranscriptionBox id="transcription-content" ref={blockRef}>
+              {mapWithAccumulator(
+                transcriptionChunks,
+                (chunk, _, acc) => {
+                  return {
+                    item: (
+                      <TranscriptionChunk
+                        key={
+                          isTakeGroup(chunk)
+                            ? `take-group-chunk-${(chunk as TakeGroup).id}`
+                            : `word-chunk-${(chunk as Word).originalIndex}-${
+                                (chunk as Word).pasteKey
+                              }`
+                        }
+                        chunk={chunk}
+                        chunkIndex={acc}
+                        onWordMouseDown={onWordMouseDown}
+                        onWordMouseMove={onWordMouseMove}
+                        dragState={dragState}
+                        isWordBeingDragged={isWordBeingDragged}
+                        mousePosition={mouse}
+                        mouseThrottled={mouseThrottled}
+                        dropBeforeIndex={dropBeforeIndex}
+                        setDropBeforeIndex={setDropBeforeIndex}
+                        cancelDrag={cancelDrag}
+                        editWord={editWord}
+                        nowPlayingWordIndex={nowPlayingWordIndex}
+                        transcription={transcription}
+                        submitWordEdit={submitWordEdit}
+                        selectionSet={ownSelectionSet}
+                        otherSelectionSets={otherSelectionSets}
+                        popoverWidth={blockWidth - 194}
+                        transcriptionBlockRef={blockRef}
+                        setPlaybackTime={setPlaybackTime}
+                      />
+                    ),
+                    acc: isTakeGroup(chunk)
+                      ? acc +
+                        getTakeGroupLength(
+                          chunk as TakeGroup,
+                          transcription.words
+                        )
+                      : acc + 1,
+                  };
+                },
+                0
+              )}
+            </TranscriptionBox>
+          );
+        }}
+      </WordDragManager>
+    </Profiler>
   );
 };
 
-export default TranscriptionBlock;
+export default React.memo(TranscriptionBlock);

--- a/src/renderer/components/Editor/TranscriptionBlock.tsx
+++ b/src/renderer/components/Editor/TranscriptionBlock.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { Box } from '@mui/material';
-import { Profiler, useCallback, useMemo, useRef } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { TakeGroup, Transcription, Word } from 'sharedTypes';
 import dispatchOp from 'renderer/store/dispatchOp';

--- a/src/renderer/components/Editor/TranscriptionBlock.tsx
+++ b/src/renderer/components/Editor/TranscriptionBlock.tsx
@@ -48,15 +48,15 @@ const TranscriptionBox = styled(Box)({
 interface Props {
   transcription: Transcription;
   nowPlayingWordIndex: number | null;
-  seekToWord: (wordIndex: number) => void;
   blockWidth: number;
+  setPlaybackTime: (time: number) => void;
 }
 
 const TranscriptionBlock = ({
-  seekToWord,
   transcription,
   nowPlayingWordIndex,
   blockWidth,
+  setPlaybackTime,
 }: Props) => {
   const editWord = useSelector((store: ApplicationStore) => store.editWord);
 
@@ -146,56 +146,54 @@ const TranscriptionBlock = ({
         cancelDrag
       ) => {
         return (
-          <Profiler id="transcription" onRender={console.log}>
-            <TranscriptionBox id="transcription-content" ref={blockRef}>
-              {mapWithAccumulator(
-                transcriptionChunks,
-                (chunk, _, acc) => {
-                  return {
-                    item: (
-                      <TranscriptionChunk
-                        key={
-                          isTakeGroup(chunk)
-                            ? `take-group-chunk-${(chunk as TakeGroup).id}`
-                            : `word-chunk-${(chunk as Word).originalIndex}-${
-                                (chunk as Word).pasteKey
-                              }`
-                        }
-                        chunk={chunk}
-                        chunkIndex={acc}
-                        onWordMouseDown={onWordMouseDown}
-                        onWordMouseMove={onWordMouseMove}
-                        dragState={dragState}
-                        isWordBeingDragged={isWordBeingDragged}
-                        mousePosition={mouse}
-                        mouseThrottled={mouseThrottled}
-                        dropBeforeIndex={dropBeforeIndex}
-                        setDropBeforeIndex={setDropBeforeIndex}
-                        cancelDrag={cancelDrag}
-                        editWord={editWord}
-                        nowPlayingWordIndex={nowPlayingWordIndex}
-                        transcription={transcription}
-                        seekToWord={seekToWord}
-                        submitWordEdit={submitWordEdit}
-                        selectionSet={ownSelectionSet}
-                        otherSelectionSets={otherSelectionSets}
-                        popoverWidth={blockWidth - 194}
-                        transcriptionBlockRef={blockRef}
-                      />
-                    ),
-                    acc: isTakeGroup(chunk)
-                      ? acc +
-                        getTakeGroupLength(
-                          chunk as TakeGroup,
-                          transcription.words
-                        )
-                      : acc + 1,
-                  };
-                },
-                0
-              )}
-            </TranscriptionBox>
-          </Profiler>
+          <TranscriptionBox id="transcription-content" ref={blockRef}>
+            {mapWithAccumulator(
+              transcriptionChunks,
+              (chunk, _, acc) => {
+                return {
+                  item: (
+                    <TranscriptionChunk
+                      key={
+                        isTakeGroup(chunk)
+                          ? `take-group-chunk-${(chunk as TakeGroup).id}`
+                          : `word-chunk-${(chunk as Word).originalIndex}-${
+                              (chunk as Word).pasteKey
+                            }`
+                      }
+                      chunk={chunk}
+                      chunkIndex={acc}
+                      onWordMouseDown={onWordMouseDown}
+                      onWordMouseMove={onWordMouseMove}
+                      dragState={dragState}
+                      isWordBeingDragged={isWordBeingDragged}
+                      mousePosition={mouse}
+                      mouseThrottled={mouseThrottled}
+                      dropBeforeIndex={dropBeforeIndex}
+                      setDropBeforeIndex={setDropBeforeIndex}
+                      cancelDrag={cancelDrag}
+                      editWord={editWord}
+                      nowPlayingWordIndex={nowPlayingWordIndex}
+                      transcription={transcription}
+                      submitWordEdit={submitWordEdit}
+                      selectionSet={ownSelectionSet}
+                      otherSelectionSets={otherSelectionSets}
+                      popoverWidth={blockWidth - 194}
+                      transcriptionBlockRef={blockRef}
+                      setPlaybackTime={setPlaybackTime}
+                    />
+                  ),
+                  acc: isTakeGroup(chunk)
+                    ? acc +
+                      getTakeGroupLength(
+                        chunk as TakeGroup,
+                        transcription.words
+                      )
+                    : acc + 1,
+                };
+              },
+              0
+            )}
+          </TranscriptionBox>
         );
       }}
     </WordDragManager>

--- a/src/renderer/components/Editor/TranscriptionBlock.tsx
+++ b/src/renderer/components/Editor/TranscriptionBlock.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { Box } from '@mui/material';
-import React, { Profiler, useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { TakeGroup, Transcription, Word } from 'sharedTypes';
 import dispatchOp from 'renderer/store/dispatchOp';
@@ -133,72 +133,70 @@ const TranscriptionBlock = ({
   );
 
   return (
-    <Profiler id="block" onRender={console.log}>
-      <WordDragManager clearSelection={clearSelection}>
-        {(
-          onWordMouseDown,
-          onWordMouseMove,
-          dragState,
-          isWordBeingDragged,
-          mouse,
-          mouseThrottled,
-          dropBeforeIndex,
-          setDropBeforeIndex,
-          cancelDrag
-        ) => {
-          return (
-            <TranscriptionBox id="transcription-content" ref={blockRef}>
-              {mapWithAccumulator(
-                transcriptionChunks,
-                (chunk, _, acc) => {
-                  return {
-                    item: (
-                      <TranscriptionChunk
-                        key={
-                          isTakeGroup(chunk)
-                            ? `take-group-chunk-${(chunk as TakeGroup).id}`
-                            : `word-chunk-${(chunk as Word).originalIndex}-${
-                                (chunk as Word).pasteKey
-                              }`
-                        }
-                        chunk={chunk}
-                        chunkIndex={acc}
-                        onWordMouseDown={onWordMouseDown}
-                        onWordMouseMove={onWordMouseMove}
-                        dragState={dragState}
-                        isWordBeingDragged={isWordBeingDragged}
-                        mousePosition={mouse}
-                        mouseThrottled={mouseThrottled}
-                        dropBeforeIndex={dropBeforeIndex}
-                        setDropBeforeIndex={setDropBeforeIndex}
-                        cancelDrag={cancelDrag}
-                        editWord={editWord}
-                        nowPlayingWordIndex={nowPlayingWordIndex}
-                        transcription={transcription}
-                        submitWordEdit={submitWordEdit}
-                        selectionSet={ownSelectionSet}
-                        otherSelectionSets={otherSelectionSets}
-                        popoverWidth={blockWidth - 194}
-                        transcriptionBlockRef={blockRef}
-                        setPlaybackTime={setPlaybackTime}
-                      />
-                    ),
-                    acc: isTakeGroup(chunk)
-                      ? acc +
-                        getTakeGroupLength(
-                          chunk as TakeGroup,
-                          transcription.words
-                        )
-                      : acc + 1,
-                  };
-                },
-                0
-              )}
-            </TranscriptionBox>
-          );
-        }}
-      </WordDragManager>
-    </Profiler>
+    <WordDragManager clearSelection={clearSelection}>
+      {(
+        onWordMouseDown,
+        onWordMouseMove,
+        dragState,
+        isWordBeingDragged,
+        mouse,
+        mouseThrottled,
+        dropBeforeIndex,
+        setDropBeforeIndex,
+        cancelDrag
+      ) => {
+        return (
+          <TranscriptionBox id="transcription-content" ref={blockRef}>
+            {mapWithAccumulator(
+              transcriptionChunks,
+              (chunk, _, acc) => {
+                return {
+                  item: (
+                    <TranscriptionChunk
+                      key={
+                        isTakeGroup(chunk)
+                          ? `take-group-chunk-${(chunk as TakeGroup).id}`
+                          : `word-chunk-${(chunk as Word).originalIndex}-${
+                              (chunk as Word).pasteKey
+                            }`
+                      }
+                      chunk={chunk}
+                      chunkIndex={acc}
+                      onWordMouseDown={onWordMouseDown}
+                      onWordMouseMove={onWordMouseMove}
+                      dragState={dragState}
+                      isWordBeingDragged={isWordBeingDragged}
+                      mousePosition={mouse}
+                      mouseThrottled={mouseThrottled}
+                      dropBeforeIndex={dropBeforeIndex}
+                      setDropBeforeIndex={setDropBeforeIndex}
+                      cancelDrag={cancelDrag}
+                      editWord={editWord}
+                      nowPlayingWordIndex={nowPlayingWordIndex}
+                      transcription={transcription}
+                      submitWordEdit={submitWordEdit}
+                      selectionSet={ownSelectionSet}
+                      otherSelectionSets={otherSelectionSets}
+                      popoverWidth={blockWidth - 194}
+                      transcriptionBlockRef={blockRef}
+                      setPlaybackTime={setPlaybackTime}
+                    />
+                  ),
+                  acc: isTakeGroup(chunk)
+                    ? acc +
+                      getTakeGroupLength(
+                        chunk as TakeGroup,
+                        transcription.words
+                      )
+                    : acc + 1,
+                };
+              },
+              0
+            )}
+          </TranscriptionBox>
+        );
+      }}
+    </WordDragManager>
   );
 };
 

--- a/src/renderer/components/Editor/TranscriptionBlock.tsx
+++ b/src/renderer/components/Editor/TranscriptionBlock.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { Box } from '@mui/material';
-import { useCallback, useMemo, useRef } from 'react';
+import { Profiler, useCallback, useMemo, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { TakeGroup, Transcription, Word } from 'sharedTypes';
 import dispatchOp from 'renderer/store/dispatchOp';
@@ -146,54 +146,56 @@ const TranscriptionBlock = ({
         cancelDrag
       ) => {
         return (
-          <TranscriptionBox id="transcription-content" ref={blockRef}>
-            {mapWithAccumulator(
-              transcriptionChunks,
-              (chunk, _, acc) => {
-                return {
-                  item: (
-                    <TranscriptionChunk
-                      key={
-                        isTakeGroup(chunk)
-                          ? `take-group-chunk-${(chunk as TakeGroup).id}`
-                          : `word-chunk-${(chunk as Word).originalIndex}-${
-                              (chunk as Word).pasteKey
-                            }`
-                      }
-                      chunk={chunk}
-                      chunkIndex={acc}
-                      onWordMouseDown={onWordMouseDown}
-                      onWordMouseMove={onWordMouseMove}
-                      dragState={dragState}
-                      isWordBeingDragged={isWordBeingDragged}
-                      mousePosition={mouse}
-                      mouseThrottled={mouseThrottled}
-                      dropBeforeIndex={dropBeforeIndex}
-                      setDropBeforeIndex={setDropBeforeIndex}
-                      cancelDrag={cancelDrag}
-                      editWord={editWord}
-                      nowPlayingWordIndex={nowPlayingWordIndex}
-                      transcription={transcription}
-                      seekToWord={seekToWord}
-                      submitWordEdit={submitWordEdit}
-                      selectionSet={ownSelectionSet}
-                      otherSelectionSets={otherSelectionSets}
-                      popoverWidth={blockWidth - 194}
-                      transcriptionBlockRef={blockRef}
-                    />
-                  ),
-                  acc: isTakeGroup(chunk)
-                    ? acc +
-                      getTakeGroupLength(
-                        chunk as TakeGroup,
-                        transcription.words
-                      )
-                    : acc + 1,
-                };
-              },
-              0
-            )}
-          </TranscriptionBox>
+          <Profiler id="transcription" onRender={console.log}>
+            <TranscriptionBox id="transcription-content" ref={blockRef}>
+              {mapWithAccumulator(
+                transcriptionChunks,
+                (chunk, _, acc) => {
+                  return {
+                    item: (
+                      <TranscriptionChunk
+                        key={
+                          isTakeGroup(chunk)
+                            ? `take-group-chunk-${(chunk as TakeGroup).id}`
+                            : `word-chunk-${(chunk as Word).originalIndex}-${
+                                (chunk as Word).pasteKey
+                              }`
+                        }
+                        chunk={chunk}
+                        chunkIndex={acc}
+                        onWordMouseDown={onWordMouseDown}
+                        onWordMouseMove={onWordMouseMove}
+                        dragState={dragState}
+                        isWordBeingDragged={isWordBeingDragged}
+                        mousePosition={mouse}
+                        mouseThrottled={mouseThrottled}
+                        dropBeforeIndex={dropBeforeIndex}
+                        setDropBeforeIndex={setDropBeforeIndex}
+                        cancelDrag={cancelDrag}
+                        editWord={editWord}
+                        nowPlayingWordIndex={nowPlayingWordIndex}
+                        transcription={transcription}
+                        seekToWord={seekToWord}
+                        submitWordEdit={submitWordEdit}
+                        selectionSet={ownSelectionSet}
+                        otherSelectionSets={otherSelectionSets}
+                        popoverWidth={blockWidth - 194}
+                        transcriptionBlockRef={blockRef}
+                      />
+                    ),
+                    acc: isTakeGroup(chunk)
+                      ? acc +
+                        getTakeGroupLength(
+                          chunk as TakeGroup,
+                          transcription.words
+                        )
+                      : acc + 1,
+                  };
+                },
+                0
+              )}
+            </TranscriptionBox>
+          </Profiler>
         );
       }}
     </WordDragManager>

--- a/src/renderer/components/Editor/TranscriptionChunk.tsx
+++ b/src/renderer/components/Editor/TranscriptionChunk.tsx
@@ -12,7 +12,7 @@ interface TranscriptionChunkProps extends TranscriptionPassThroughProps {
   chunk: Word | TakeGroup;
   chunkIndex: number;
   onWordMouseDown: WordMouseHandler;
-  onWordMouseMove: any;
+  onWordMouseMove: (wordIndex: number) => void;
   mousePosition: MousePosition | null;
   nowPlayingWordIndex: number | null;
   selectionSet: Set<number>;

--- a/src/renderer/components/Editor/TranscriptionChunk.tsx
+++ b/src/renderer/components/Editor/TranscriptionChunk.tsx
@@ -1,33 +1,22 @@
 import { MousePosition } from '@react-hook/mouse-position';
-import { ClientId } from 'collabTypes/collabShadowTypes';
-import { Dispatch, RefObject, SetStateAction } from 'react';
+import React from 'react';
 import { isTakeGroup } from 'renderer/utils/takeDetection';
 import { TakeGroup, Transcription, Word } from 'sharedTypes';
-import TakeGroupComponent from './TakeGroupComponent';
-import { DragState, WordMouseHandler } from './WordDragManager';
+import TakeGroupComponent, {
+  TranscriptionPassThroughProps,
+} from './TakeGroupComponent';
+import { WordMouseHandler } from './WordDragManager';
 import WordOuterComponent from './WordOuterComponent';
 
-interface TranscriptionChunkProps {
+interface TranscriptionChunkProps extends TranscriptionPassThroughProps {
   chunk: Word | TakeGroup;
   chunkIndex: number;
   onWordMouseDown: WordMouseHandler;
   onWordMouseMove: any;
-  dragState: DragState;
-  isWordBeingDragged: (wordIndex: number) => boolean;
   mousePosition: MousePosition | null;
-  mouseThrottled: MousePosition | null;
-  dropBeforeIndex: number | null;
-  setDropBeforeIndex: Dispatch<SetStateAction<number | null>>;
-  cancelDrag: () => void;
-  editWord: any;
   nowPlayingWordIndex: number | null;
-  transcription: Transcription;
-  submitWordEdit: () => void;
   selectionSet: Set<number>;
-  otherSelectionSets: Record<ClientId, Set<number>>;
-  popoverWidth: number;
-  transcriptionBlockRef: RefObject<HTMLElement>;
-  setPlaybackTime: (time: number) => void;
+  transcription: Transcription;
 }
 
 const TranscriptionChunk = ({
@@ -35,22 +24,11 @@ const TranscriptionChunk = ({
   chunkIndex,
   onWordMouseDown,
   onWordMouseMove,
-  dragState,
-  isWordBeingDragged,
   mousePosition,
-  mouseThrottled,
-  dropBeforeIndex,
-  setDropBeforeIndex,
-  cancelDrag,
-  editWord,
   nowPlayingWordIndex,
-  transcription,
-  submitWordEdit,
   selectionSet,
-  otherSelectionSets,
-  popoverWidth,
-  transcriptionBlockRef,
-  setPlaybackTime,
+  transcription,
+  ...passThroughProps
 }: TranscriptionChunkProps) => {
   return isTakeGroup(chunk) ? (
     <TakeGroupComponent
@@ -58,50 +36,34 @@ const TranscriptionChunk = ({
       chunkIndex={chunkIndex}
       onWordMouseDown={onWordMouseDown}
       onWordMouseMove={onWordMouseMove}
-      dragState={dragState}
-      isWordBeingDragged={isWordBeingDragged}
       mousePosition={mousePosition}
-      mouseThrottled={mouseThrottled}
-      dropBeforeIndex={dropBeforeIndex}
-      setDropBeforeIndex={setDropBeforeIndex}
-      cancelDrag={cancelDrag}
-      editWord={editWord}
       nowPlayingWordIndex={nowPlayingWordIndex}
-      transcription={transcription}
-      submitWordEdit={submitWordEdit}
       selectionSet={selectionSet}
-      otherSelectionSets={otherSelectionSets}
-      popoverWidth={popoverWidth}
-      transcriptionBlockRef={transcriptionBlockRef}
-      setPlaybackTime={setPlaybackTime}
+      transcription={transcription}
+      {...passThroughProps}
     />
   ) : (
     <WordOuterComponent
       word={chunk as Word}
+      prevWord={chunkIndex > 0 ? transcription.words[chunkIndex - 1] : null}
+      nextWord={
+        chunkIndex < transcription.words.length - 1
+          ? transcription.words[chunkIndex + 1]
+          : null
+      }
       index={chunkIndex}
-      transcription={transcription}
       isSelected={selectionSet.has(chunkIndex)}
       isPrevWordSelected={selectionSet.has(chunkIndex - 1)}
       isNextWordSelected={selectionSet.has(chunkIndex + 1)}
-      otherSelectionSets={otherSelectionSets}
-      onWordMouseDown={onWordMouseDown}
-      onWordMouseMove={onWordMouseMove}
-      dragState={dragState}
-      isWordBeingDragged={isWordBeingDragged}
+      onMouseDown={onWordMouseDown}
+      onMouseMove={onWordMouseMove}
       mouse={mousePosition}
-      mouseThrottled={mouseThrottled}
-      dropBeforeIndex={dropBeforeIndex}
-      setDropBeforeIndex={setDropBeforeIndex}
-      cancelDrag={cancelDrag}
-      submitWordEdit={submitWordEdit}
-      editWord={editWord}
       isPlaying={nowPlayingWordIndex === chunkIndex}
       isInInactiveTake={false}
-      popoverWidth={popoverWidth}
-      transcriptionBlockRef={transcriptionBlockRef}
-      setPlaybackTime={setPlaybackTime}
+      transcriptionLength={transcription.words.length}
+      {...passThroughProps}
     />
   );
 };
 
-export default TranscriptionChunk;
+export default React.memo(TranscriptionChunk);

--- a/src/renderer/components/Editor/TranscriptionChunk.tsx
+++ b/src/renderer/components/Editor/TranscriptionChunk.tsx
@@ -22,12 +22,12 @@ interface TranscriptionChunkProps {
   editWord: any;
   nowPlayingWordIndex: number | null;
   transcription: Transcription;
-  seekToWord: (wordIndex: number) => void;
   submitWordEdit: () => void;
   selectionSet: Set<number>;
   otherSelectionSets: Record<ClientId, Set<number>>;
   popoverWidth: number;
   transcriptionBlockRef: RefObject<HTMLElement>;
+  setPlaybackTime: (time: number) => void;
 }
 
 const TranscriptionChunk = ({
@@ -45,12 +45,12 @@ const TranscriptionChunk = ({
   editWord,
   nowPlayingWordIndex,
   transcription,
-  seekToWord,
   submitWordEdit,
   selectionSet,
   otherSelectionSets,
   popoverWidth,
   transcriptionBlockRef,
+  setPlaybackTime,
 }: TranscriptionChunkProps) => {
   return isTakeGroup(chunk) ? (
     <TakeGroupComponent
@@ -68,20 +68,21 @@ const TranscriptionChunk = ({
       editWord={editWord}
       nowPlayingWordIndex={nowPlayingWordIndex}
       transcription={transcription}
-      seekToWord={seekToWord}
       submitWordEdit={submitWordEdit}
       selectionSet={selectionSet}
       otherSelectionSets={otherSelectionSets}
       popoverWidth={popoverWidth}
       transcriptionBlockRef={transcriptionBlockRef}
+      setPlaybackTime={setPlaybackTime}
     />
   ) : (
     <WordOuterComponent
       word={chunk as Word}
       index={chunkIndex}
       transcription={transcription}
-      seekToWord={seekToWord}
-      selectionSet={selectionSet}
+      isSelected={selectionSet.has(chunkIndex)}
+      isPrevWordSelected={selectionSet.has(chunkIndex - 1)}
+      isNextWordSelected={selectionSet.has(chunkIndex + 1)}
       otherSelectionSets={otherSelectionSets}
       onWordMouseDown={onWordMouseDown}
       onWordMouseMove={onWordMouseMove}
@@ -94,10 +95,11 @@ const TranscriptionChunk = ({
       cancelDrag={cancelDrag}
       submitWordEdit={submitWordEdit}
       editWord={editWord}
-      nowPlayingWordIndex={nowPlayingWordIndex}
+      isPlaying={nowPlayingWordIndex === chunkIndex}
       isInInactiveTake={false}
       popoverWidth={popoverWidth}
       transcriptionBlockRef={transcriptionBlockRef}
+      setPlaybackTime={setPlaybackTime}
     />
   );
 };

--- a/src/renderer/components/Editor/VideoController.tsx
+++ b/src/renderer/components/Editor/VideoController.tsx
@@ -1,6 +1,7 @@
 import { Forward10, Pause, PlayArrow, Replay10 } from '@mui/icons-material';
 import { Box, IconButton, styled } from '@mui/material';
 import { secondToTimestampUI } from 'main/timeUtils';
+import React, { useCallback, useMemo } from 'react';
 import colors from '../../colors';
 
 const VideoControllerBox = styled(Box)({
@@ -15,16 +16,28 @@ const VideoControllerBox = styled(Box)({
   alignItems: 'center',
 });
 
+const TimeDisplay = styled(Box)({
+  backgroundColor: colors.grey[600],
+  fontWeight: 'regular',
+  fontSize: '24px',
+  borderRadius: '5px',
+  padding: '0 19px',
+  marginRight: '47px',
+  width: '152px',
+  textAlign: 'left',
+  fontFamily: '"Roboto Mono", monospace',
+});
+
 interface TogglePlayButtonProps {
   isPlaying: boolean;
 }
 
-const TogglePlayButton = ({ isPlaying }: TogglePlayButtonProps) => {
-  if (!isPlaying) {
-    return <PlayArrow sx={{ fontSize: '42px', color: colors.yellow[500] }} />;
+const TogglePlayButton = React.memo(({ isPlaying }: TogglePlayButtonProps) => {
+  if (isPlaying) {
+    return <Pause sx={{ fontSize: '42px', color: colors.yellow[500] }} />;
   }
-  return <Pause sx={{ fontSize: '42px', color: colors.yellow[500] }} />;
-};
+  return <PlayArrow sx={{ fontSize: '42px', color: colors.yellow[500] }} />;
+});
 
 interface Props {
   time: number;
@@ -43,31 +56,19 @@ const VideoController = ({
   seekForward,
   seekBack,
 }: Props) => {
-  const onClickPlayPause = () => {
+  const onClickPlayPause = useCallback(() => {
     if (isPlaying) {
       pause();
     } else {
       play();
     }
-  };
+  }, [pause, play, isPlaying]);
+
+  const timeDisplay = useMemo(() => secondToTimestampUI(time), [time]);
 
   return (
     <VideoControllerBox>
-      <div
-        style={{
-          backgroundColor: colors.grey[600],
-          fontWeight: 'regular',
-          fontSize: '24px',
-          borderRadius: '5px',
-          padding: '0 19px',
-          marginRight: '47px',
-          width: '152px',
-          textAlign: 'left',
-          fontFamily: '"Roboto Mono", monospace',
-        }}
-      >
-        {secondToTimestampUI(time)}
-      </div>
+      <TimeDisplay>{timeDisplay}</TimeDisplay>
       <IconButton onClick={seekBack}>
         <Replay10 sx={{ fontSize: '36px', color: colors.grey[400] }} />
       </IconButton>
@@ -81,4 +82,4 @@ const VideoController = ({
   );
 };
 
-export default VideoController;
+export default React.memo(VideoController);

--- a/src/renderer/components/Editor/WordComponent.tsx
+++ b/src/renderer/components/Editor/WordComponent.tsx
@@ -6,7 +6,6 @@ import React, {
   useMemo,
   useState,
   useCallback,
-  Profiler,
 } from 'react';
 import { MousePosition } from '@react-hook/mouse-position';
 import { pointIsInsideRect } from 'renderer/utils/geometry';
@@ -22,7 +21,6 @@ import {
   getColourForIndex,
   getTextWidth,
 } from 'renderer/utils/ui';
-import profileWords from 'renderer/utils/profile';
 import { DragState, WordMouseHandler } from './WordDragManager';
 import { handleSelectWord } from '../../editor/selection';
 import colors from '../../colors';

--- a/src/renderer/components/Editor/WordComponent.tsx
+++ b/src/renderer/components/Editor/WordComponent.tsx
@@ -225,7 +225,7 @@ const WordComponent = ({
         setAwaitingSecondClick(false);
       }, DOUBLE_CLICK_THRESHOLD);
 
-      setPlaybackTime(outputStartTime);
+      setPlaybackTime(outputStartTime + 0.01); // add a small amount so the correct word is selected
       handleSelectWord(event, index);
 
       // Prevent event from being received by the transcription block and therefore intercepted,

--- a/src/renderer/components/Editor/WordComponent.tsx
+++ b/src/renderer/components/Editor/WordComponent.tsx
@@ -55,9 +55,19 @@ const CONFIDENCE_THRESHOLD_LOW = 0.4;
 // pixels
 const MIN_EDIT_WIDTH = 10;
 
-interface Props {
-  index: number;
+export interface WordPassThroughProps {
+  isInInactiveTake: boolean;
   isPlaying: boolean;
+  onMouseDown: WordMouseHandler;
+  onMouseMove: (index: number) => void;
+  cancelDrag: () => void;
+  submitWordEdit: () => void;
+  setDropBeforeIndex: (index: number) => void;
+  setPlaybackTime: (time: number) => void;
+}
+
+interface Props extends WordPassThroughProps {
+  index: number;
   isSelected: boolean;
   confidence: number;
   isSelectedLeftCap: boolean; // whether the word is the first word in a contiguous selection
@@ -66,21 +76,13 @@ interface Props {
   isSelectedByAnotherClientLeftCap: boolean;
   isSelectedByAnotherClientRightCap: boolean;
   text: string;
-  onMouseDown: WordMouseHandler;
-  onMouseMove: (index: number) => void;
   dragState: DragState; // current state of ANY drag (null if no word being dragged)
   isBeingDragged: boolean; // whether THIS word is currently being dragged
   mouse: MousePosition | null;
   isDropBeforeActive: boolean;
   isDropAfterActive: boolean;
-  setDropBeforeIndex: (index: number) => void;
-  cancelDrag: () => void;
-  submitWordEdit: () => void;
   isBeingEdited: boolean;
   editText: string | null;
-  isInInactiveTake: boolean;
-  isShowingConfidenceUnderlines: boolean;
-  setPlaybackTime: (time: number) => void;
   outputStartTime: number;
 }
 
@@ -105,7 +107,6 @@ const WordComponent = ({
   isBeingEdited,
   editText,
   isInInactiveTake,
-  isShowingConfidenceUnderlines,
   selectedByClientWithIndex,
   isSelectedByAnotherClientLeftCap,
   isSelectedByAnotherClientRightCap,
@@ -287,19 +288,17 @@ const WordComponent = ({
               : 0,
           };
         }
-        if (isShowingConfidenceUnderlines) {
-          if (confidence < CONFIDENCE_THRESHOLD_LOW) {
-            return {
-              borderBottom: `2px solid rgba(255, 0, 0, 0.6)`,
-              marginBottom: 0,
-            };
-          }
-          if (confidence < CONFIDENCE_THRESHOLD_MEDIUM) {
-            return {
-              borderBottom: `2px solid ${colors.yellow[500]}88`,
-              marginBottom: 0,
-            };
-          }
+        if (confidence < CONFIDENCE_THRESHOLD_LOW) {
+          return {
+            borderBottom: `2px solid rgba(255, 0, 0, 0.6)`,
+            marginBottom: 0,
+          };
+        }
+        if (confidence < CONFIDENCE_THRESHOLD_MEDIUM) {
+          return {
+            borderBottom: `2px solid ${colors.yellow[500]}88`,
+            marginBottom: 0,
+          };
         }
         return {};
       })(),
@@ -313,7 +312,6 @@ const WordComponent = ({
       isSelectedByAnotherClientLeftCap,
       isSelectedByAnotherClientRightCap,
       selectedByClientWithIndex,
-      isShowingConfidenceUnderlines,
       confidence,
     ]
   );
@@ -428,4 +426,4 @@ const WordComponent = ({
   );
 };
 
-export default WordComponent;
+export default React.memo(WordComponent);

--- a/src/renderer/components/Editor/WordComponent.tsx
+++ b/src/renderer/components/Editor/WordComponent.tsx
@@ -4,9 +4,9 @@ import React, {
   useEffect,
   useRef,
   useMemo,
-  RefObject,
   useState,
   useCallback,
+  Profiler,
 } from 'react';
 import { MousePosition } from '@react-hook/mouse-position';
 import { pointIsInsideRect } from 'renderer/utils/geometry';
@@ -22,7 +22,8 @@ import {
   getColourForIndex,
   getTextWidth,
 } from 'renderer/utils/ui';
-import { DragState } from './WordDragManager';
+import profileWords from 'renderer/utils/profile';
+import { DragState, WordMouseHandler } from './WordDragManager';
 import { handleSelectWord } from '../../editor/selection';
 import colors from '../../colors';
 
@@ -45,13 +46,19 @@ const makeWordInner = (isDragActive: boolean, isInInactiveTake: boolean) =>
     },
   });
 
+const defaultStyles: React.CSSProperties = {
+  zIndex: 0,
+};
+
 // thresholds below which words are suggested to be corrected - highlight colour depends on which threshold is crossed
 const CONFIDENCE_THRESHOLD_MEDIUM = 0.6;
 const CONFIDENCE_THRESHOLD_LOW = 0.4;
 
+// pixels
+const MIN_EDIT_WIDTH = 10;
+
 interface Props {
   index: number;
-  seekToWord: () => void;
   isPlaying: boolean;
   isSelected: boolean;
   confidence: number;
@@ -61,10 +68,8 @@ interface Props {
   isSelectedByAnotherClientLeftCap: boolean;
   isSelectedByAnotherClientRightCap: boolean;
   text: string;
-  onMouseDown: (
-    wordRef: RefObject<HTMLDivElement>
-  ) => MouseEventHandler<HTMLDivElement>;
-  onMouseMove: () => void;
+  onMouseDown: WordMouseHandler;
+  onMouseMove: (index: number) => void;
   dragState: DragState; // current state of ANY drag (null if no word being dragged)
   isBeingDragged: boolean; // whether THIS word is currently being dragged
   mouse: MousePosition | null;
@@ -77,11 +82,12 @@ interface Props {
   editText: string | null;
   isInInactiveTake: boolean;
   isShowingConfidenceUnderlines: boolean;
+  setPlaybackTime: (time: number) => void;
+  outputStartTime: number;
 }
 
 const WordComponent = ({
   index,
-  seekToWord,
   isPlaying,
   isSelected,
   confidence,
@@ -105,6 +111,8 @@ const WordComponent = ({
   selectedByClientWithIndex,
   isSelectedByAnotherClientLeftCap,
   isSelectedByAnotherClientRightCap,
+  setPlaybackTime,
+  outputStartTime,
 }: Props) => {
   const dispatch = useDispatch();
 
@@ -122,13 +130,19 @@ const WordComponent = ({
 
   const ref = useRef<HTMLDivElement>(null);
 
-  const refRect = ref.current?.getBoundingClientRect();
-  const xPosition = refRect?.left ?? 0;
-  const yPosition = refRect?.top ?? 0;
-  const halfWidth = (ref.current?.offsetWidth ?? 0) / 2;
-  const height = ref.current?.offsetHeight ?? 0;
-  const mouseX = mouse?.clientX ?? 0;
-  const mouseY = mouse?.clientY ?? 0;
+  const { xPosition, yPosition, halfWidth, height, mouseX, mouseY } =
+    useMemo(() => {
+      const refRect = ref.current?.getBoundingClientRect();
+
+      return {
+        xPosition: refRect?.left ?? 0,
+        yPosition: refRect?.top ?? 0,
+        halfWidth: (ref.current?.offsetWidth ?? 0) / 2,
+        height: ref.current?.offsetHeight ?? 0,
+        mouseX: mouse?.clientX ?? 0,
+        mouseY: mouse?.clientY ?? 0,
+      };
+    }, [ref, mouse]);
 
   useEffect(() => {
     if (
@@ -190,137 +204,178 @@ const WordComponent = ({
     index,
   ]);
 
-  const startEditing = () => {
+  const startEditing = useCallback(() => {
     dispatch(editWordStarted(index, text));
-  };
+  }, [dispatch, index, text]);
 
-  const onClick: MouseEventHandler<HTMLDivElement> = (event) => {
-    if (isInInactiveTake) {
-      return;
-    }
-
-    if (awaitingSecondClick) {
-      startEditing();
-      return;
-    }
-
-    setAwaitingSecondClick(true);
-    const DOUBLE_CLICK_THRESHOLD = 500; // ms
-    setTimeout(() => {
-      setAwaitingSecondClick(false);
-    }, DOUBLE_CLICK_THRESHOLD);
-
-    seekToWord();
-    handleSelectWord(event, index);
-
-    // Prevent event from being received by the transcription block and therefore intercepted,
-    // which would clear the selection
-    event.stopPropagation();
-  };
-
-  const defaultStyles: React.CSSProperties = {
-    zIndex: 0,
-  };
-
-  const highlightStyles: React.CSSProperties = (() => {
-    if (isBeingEdited) {
-      return {};
-    }
-    if (isSelected || isBeingDragged) {
-      return {
-        background: `${colors.blue[500]}cc`,
-        color: colors.white,
-        borderTopLeftRadius: isSelectedLeftCap ? BORDER_RADIUS_AMOUNT : 0,
-        borderBottomLeftRadius: isSelectedLeftCap ? BORDER_RADIUS_AMOUNT : 0,
-        borderTopRightRadius: isSelectedRightCap ? BORDER_RADIUS_AMOUNT : 0,
-        borderBottomRightRadius: isSelectedRightCap ? BORDER_RADIUS_AMOUNT : 0,
-      };
-    }
-    if (isPlaying) {
-      return {
-        background: `${colors.yellow[500]}cc`,
-        color: colors.white,
-        boxShadow: '0 0 10px 0 rgba(0, 0, 0, 0.5)',
-        borderRadius: BORDER_RADIUS_AMOUNT,
-      };
-    }
-    if (selectedByClientWithIndex !== null) {
-      return {
-        background: `${getColourForIndex(selectedByClientWithIndex)}cc`,
-        color: colors.white,
-        borderTopLeftRadius: isSelectedByAnotherClientLeftCap
-          ? BORDER_RADIUS_AMOUNT
-          : 0,
-        borderBottomLeftRadius: isSelectedByAnotherClientLeftCap
-          ? BORDER_RADIUS_AMOUNT
-          : 0,
-        borderTopRightRadius: isSelectedByAnotherClientRightCap
-          ? BORDER_RADIUS_AMOUNT
-          : 0,
-        borderBottomRightRadius: isSelectedByAnotherClientRightCap
-          ? BORDER_RADIUS_AMOUNT
-          : 0,
-      };
-    }
-    if (isShowingConfidenceUnderlines) {
-      if (confidence < CONFIDENCE_THRESHOLD_LOW) {
-        return {
-          borderBottom: `2px solid rgba(255, 0, 0, 0.6)`,
-          marginBottom: 0,
-        };
+  const onClick: MouseEventHandler<HTMLDivElement> = useCallback(
+    (event) => {
+      if (isInInactiveTake) {
+        return;
       }
-      if (confidence < CONFIDENCE_THRESHOLD_MEDIUM) {
-        return {
-          borderBottom: `2px solid ${colors.yellow[500]}88`,
-          marginBottom: 0,
-        };
+
+      if (awaitingSecondClick) {
+        startEditing();
+        return;
       }
-    }
-    return {};
-  })();
 
-  const dragStyles: React.CSSProperties = isBeingDragged
-    ? {
-        position: 'fixed',
-        left: mouseX + (dragState?.offset.x ?? 0),
-        top: mouseY + (dragState?.offset.y ?? 0),
-        zIndex: 100,
+      setAwaitingSecondClick(true);
+      const DOUBLE_CLICK_THRESHOLD = 500; // ms
+      setTimeout(() => {
+        setAwaitingSecondClick(false);
+      }, DOUBLE_CLICK_THRESHOLD);
+
+      setPlaybackTime(outputStartTime);
+      handleSelectWord(event, index);
+
+      // Prevent event from being received by the transcription block and therefore intercepted,
+      // which would clear the selection
+      event.stopPropagation();
+    },
+    [
+      isInInactiveTake,
+      awaitingSecondClick,
+      startEditing,
+      setAwaitingSecondClick,
+      setPlaybackTime,
+      outputStartTime,
+      index,
+    ]
+  );
+
+  const highlightStyles: React.CSSProperties = useMemo(
+    () =>
+      (() => {
+        if (isBeingEdited) {
+          return {};
+        }
+        if (isSelected || isBeingDragged) {
+          return {
+            background: `${colors.blue[500]}cc`,
+            color: colors.white,
+            borderTopLeftRadius: isSelectedLeftCap ? BORDER_RADIUS_AMOUNT : 0,
+            borderBottomLeftRadius: isSelectedLeftCap
+              ? BORDER_RADIUS_AMOUNT
+              : 0,
+            borderTopRightRadius: isSelectedRightCap ? BORDER_RADIUS_AMOUNT : 0,
+            borderBottomRightRadius: isSelectedRightCap
+              ? BORDER_RADIUS_AMOUNT
+              : 0,
+          };
+        }
+        if (isPlaying) {
+          return {
+            background: `${colors.yellow[500]}cc`,
+            color: colors.white,
+            boxShadow: '0 0 10px 0 rgba(0, 0, 0, 0.5)',
+            borderRadius: BORDER_RADIUS_AMOUNT,
+          };
+        }
+        if (selectedByClientWithIndex !== null) {
+          return {
+            background: `${getColourForIndex(selectedByClientWithIndex)}cc`,
+            color: colors.white,
+            borderTopLeftRadius: isSelectedByAnotherClientLeftCap
+              ? BORDER_RADIUS_AMOUNT
+              : 0,
+            borderBottomLeftRadius: isSelectedByAnotherClientLeftCap
+              ? BORDER_RADIUS_AMOUNT
+              : 0,
+            borderTopRightRadius: isSelectedByAnotherClientRightCap
+              ? BORDER_RADIUS_AMOUNT
+              : 0,
+            borderBottomRightRadius: isSelectedByAnotherClientRightCap
+              ? BORDER_RADIUS_AMOUNT
+              : 0,
+          };
+        }
+        if (isShowingConfidenceUnderlines) {
+          if (confidence < CONFIDENCE_THRESHOLD_LOW) {
+            return {
+              borderBottom: `2px solid rgba(255, 0, 0, 0.6)`,
+              marginBottom: 0,
+            };
+          }
+          if (confidence < CONFIDENCE_THRESHOLD_MEDIUM) {
+            return {
+              borderBottom: `2px solid ${colors.yellow[500]}88`,
+              marginBottom: 0,
+            };
+          }
+        }
+        return {};
+      })(),
+    [
+      isBeingEdited,
+      isSelected,
+      isBeingDragged,
+      isPlaying,
+      isSelectedLeftCap,
+      isSelectedRightCap,
+      isSelectedByAnotherClientLeftCap,
+      isSelectedByAnotherClientRightCap,
+      selectedByClientWithIndex,
+      isShowingConfidenceUnderlines,
+      confidence,
+    ]
+  );
+
+  const dragStyles: React.CSSProperties = useMemo(
+    () =>
+      isBeingDragged
+        ? {
+            position: 'fixed',
+            left: mouseX + (dragState?.offset.x ?? 0),
+            top: mouseY + (dragState?.offset.y ?? 0),
+            zIndex: 100,
+          }
+        : {},
+    [isBeingDragged, mouseX, mouseY, dragState]
+  );
+
+  const style = useMemo(
+    () => ({
+      ...defaultStyles,
+      ...highlightStyles,
+      ...dragStyles,
+    }),
+    [highlightStyles, dragStyles]
+  );
+
+  const submitIfEnter = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === 'Enter') {
+        // Save and close edit
+        submitWordEdit();
+      } else if (event.key === 'Escape') {
+        // Close edit without saving
+        dispatch(editWordFinished());
       }
-    : {};
-
-  const style = {
-    ...defaultStyles,
-    ...highlightStyles,
-    ...dragStyles,
-  };
-
-  const submitIfEnter = (event: React.KeyboardEvent) => {
-    if (event.key === 'Enter') {
-      // Save and close edit
-      submitWordEdit();
-    } else if (event.key === 'Escape') {
-      // Close edit without saving
-      dispatch(editWordFinished());
-    }
-  };
+    },
+    [submitWordEdit, dispatch]
+  );
 
   const WordInner = useMemo(
     () => makeWordInner(dragState !== null, isInInactiveTake),
     [dragState, isInInactiveTake]
   );
 
-  const setEditText = (value: string) => {
-    dispatch(editWordUpdated(value));
-  };
+  const setEditText = useCallback(
+    (value: string) => {
+      dispatch(editWordUpdated(value));
+    },
+    [dispatch]
+  );
 
-  const onMouseUp: (event: React.MouseEvent) => void = (event) => {
-    // Prevent edit from being cancelled if clicking the word
-    if (isBeingEdited) {
-      event.stopPropagation();
-    }
-  };
-
-  const MIN_EDIT_WIDTH = 10;
+  const onMouseUp = useCallback(
+    (event) => {
+      // Prevent edit from being cancelled if clicking the word
+      if (isBeingEdited) {
+        event.stopPropagation();
+      }
+    },
+    [isBeingEdited]
+  );
 
   const onMouseDownWrapped = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
@@ -328,9 +383,14 @@ const WordComponent = ({
         return null;
       }
 
-      return onMouseDown(ref)(event);
+      return onMouseDown(index)(ref)(event);
     },
-    [isInInactiveTake, onMouseDown, ref]
+    [isInInactiveTake, index, onMouseDown, ref]
+  );
+
+  const onMouseMoveWrapped = useCallback(
+    () => onMouseMove(index),
+    [onMouseMove, index]
   );
 
   return (
@@ -339,7 +399,7 @@ const WordComponent = ({
       onClick={onClick}
       onMouseUp={onMouseUp}
       onMouseDown={onMouseDownWrapped}
-      onMouseMove={onMouseMove}
+      onMouseMove={onMouseMoveWrapped}
       style={{ ...style, position: isBeingDragged ? 'fixed' : 'relative' }}
     >
       {isBeingEdited ? (

--- a/src/renderer/components/Editor/WordDragManager.tsx
+++ b/src/renderer/components/Editor/WordDragManager.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 
-import {
+import React, {
   Dispatch,
   MouseEventHandler,
   RefObject,
@@ -235,4 +235,4 @@ const WordDragManager = ({ clearSelection, children }: Props) => {
   );
 };
 
-export default WordDragManager;
+export default React.memo(WordDragManager);

--- a/src/renderer/components/Editor/WordDragManager.tsx
+++ b/src/renderer/components/Editor/WordDragManager.tsx
@@ -8,6 +8,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useState,
 } from 'react';
 import useMouse, { MousePosition } from '@react-hook/mouse-position';
@@ -186,23 +187,50 @@ const WordDragManager = ({ clearSelection, children }: Props) => {
     setDragState(null);
   }, [setDragState]);
 
+  const mouseOrNull = useMemo(
+    () => (dragState === null ? null : mouse),
+    [dragState, mouse]
+  );
+
+  const mouseThrottledOrNull = useMemo(
+    () => (dragState === null ? null : mouseThrottled),
+    [dragState, mouseThrottled]
+  );
+
+  const childrenRendered = useMemo(
+    () =>
+      children(
+        onWordMouseDown,
+        onWordMouseMoveDebounced,
+        dragState,
+        isWordBeingDragged,
+        mouseOrNull,
+        mouseThrottledOrNull,
+        dropBeforeIndex,
+        setDropBeforeIndex,
+        cancelDrag
+      ),
+    [
+      onWordMouseDown,
+      onWordMouseMoveDebounced,
+      dragState,
+      isWordBeingDragged,
+      mouseOrNull,
+      mouseThrottledOrNull,
+      dropBeforeIndex,
+      setDropBeforeIndex,
+      cancelDrag,
+      children,
+    ]
+  );
+
   return (
     <div
       id="word-drag-manager"
       style={{ height: '100%' }}
       onMouseUp={onMouseUp}
     >
-      {children(
-        onWordMouseDown,
-        onWordMouseMoveDebounced,
-        dragState,
-        isWordBeingDragged,
-        dragState === null ? null : mouse,
-        dragState === null ? null : mouseThrottled,
-        dropBeforeIndex,
-        setDropBeforeIndex,
-        cancelDrag
-      )}
+      {childrenRendered}
     </div>
   );
 };

--- a/src/renderer/components/Editor/WordOuterComponent.tsx
+++ b/src/renderer/components/Editor/WordOuterComponent.tsx
@@ -1,9 +1,10 @@
 import { Box, styled } from '@mui/material';
 import { MousePosition } from '@react-hook/mouse-position';
 import { ClientId } from 'collabTypes/collabShadowTypes';
-import { Fragment, RefObject, useMemo } from 'react';
+import { Fragment, Profiler, RefObject, useEffect, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { ApplicationStore } from 'renderer/store/sharedHelpers';
+import profileWords from 'renderer/utils/profile';
 import { Word, Transcription } from 'sharedTypes';
 import EditMarker from './EditMarker';
 import WordComponent from './WordComponent';
@@ -67,6 +68,15 @@ const WordOuterComponent = ({
     (store: ApplicationStore) => store.isShowingConfidenceUnderlines
   );
 
+  useEffect(() => {
+    console.log(
+      editWord,
+      isInInactiveTake,
+      popoverWidth,
+      transcriptionBlockRef
+    );
+  }, [editWord, isInInactiveTake, popoverWidth, transcriptionBlockRef]);
+
   const isSelected = useMemo(
     () => selectionSet.has(index),
     [selectionSet, index]
@@ -120,82 +130,88 @@ const WordOuterComponent = ({
     ]);
 
   return (
-    <WordAndSpaceContainer
-      key={`container-${word.originalIndex}-${word.pasteKey}`}
-    >
-      {word.deleted ? (
-        <EditMarker
-          key={`edit-marker-${word.originalIndex}-${word.pasteKey}`}
-          transcription={transcription}
-          word={word}
-          index={index}
-          isSelected={isSelected}
-          selectedByClientWithIndex={selectedByClientWithIndex}
-          popoverWidth={popoverWidth}
-          transcriptionBlockRef={transcriptionBlockRef}
-        />
-      ) : (
-        <Fragment key={`${word.originalIndex}-${word.pasteKey}`}>
-          <WordSpace
-            key={`space-${word.originalIndex}-${word.pasteKey}`}
-            isDropMarkerActive={dragState !== null && dropBeforeIndex === index}
-            isBetweenHighlightedWords={
-              selectionSet.has(index - 1) && selectionSet.has(index)
-            }
-            highlightedByClientWithIndex={
-              isSelectedByAnotherClientLeftCap
-                ? null
-                : selectedByClientWithIndex
-            }
-          />
-          <WordComponent
-            key={`word-${word.originalIndex}-${word.pasteKey}`}
-            seekToWord={() => seekToWord(index)}
-            isPlaying={index === nowPlayingWordIndex}
-            isSelected={isSelected}
-            isSelectedLeftCap={
-              selectionSet.has(index) && !selectionSet.has(index - 1)
-            }
-            isSelectedRightCap={
-              selectionSet.has(index) && !selectionSet.has(index + 1)
-            }
-            selectedByClientWithIndex={selectedByClientWithIndex}
-            isSelectedByAnotherClientLeftCap={isSelectedByAnotherClientLeftCap}
-            isSelectedByAnotherClientRightCap={
-              isSelectedByAnotherClientRightCap
-            }
-            text={word.word}
-            confidence={word.confidence ?? 1}
+    <Profiler id="wordouter" onRender={profileWords}>
+      <WordAndSpaceContainer
+        key={`container-${word.originalIndex}-${word.pasteKey}`}
+      >
+        {word.deleted ? (
+          <EditMarker
+            key={`edit-marker-${word.originalIndex}-${word.pasteKey}`}
+            transcription={transcription}
+            word={word}
             index={index}
-            onMouseDown={onWordMouseDown(index)}
-            onMouseMove={() => onWordMouseMove(index)}
-            dragState={dragState}
-            isBeingDragged={isWordBeingDragged(index)}
-            mouse={isWordBeingDragged(index) ? mouse : mouseThrottled}
-            isDropBeforeActive={dropBeforeIndex === index}
-            isDropAfterActive={dropBeforeIndex === index + 1}
-            setDropBeforeIndex={setDropBeforeIndex}
-            cancelDrag={cancelDrag}
-            submitWordEdit={submitWordEdit}
-            isBeingEdited={editWord?.index === index}
-            editText={editWord?.text ?? null}
-            isInInactiveTake={isInInactiveTake}
-            isShowingConfidenceUnderlines={isShowingConfidenceUnderlines}
+            isSelected={isSelected}
+            selectedByClientWithIndex={selectedByClientWithIndex}
+            popoverWidth={popoverWidth}
+            transcriptionBlockRef={transcriptionBlockRef}
           />
-          {index === transcription.words.length - 1 && (
+        ) : (
+          <Fragment key={`${word.originalIndex}-${word.pasteKey}`}>
             <WordSpace
-              key="space-end"
+              key={`space-${word.originalIndex}-${word.pasteKey}`}
               isDropMarkerActive={
-                dragState !== null &&
-                dropBeforeIndex === transcription.words.length
+                dragState !== null && dropBeforeIndex === index
               }
-              isBetweenHighlightedWords={false}
-              highlightedByClientWithIndex={null}
+              isBetweenHighlightedWords={
+                selectionSet.has(index - 1) && selectionSet.has(index)
+              }
+              highlightedByClientWithIndex={
+                isSelectedByAnotherClientLeftCap
+                  ? null
+                  : selectedByClientWithIndex
+              }
             />
-          )}
-        </Fragment>
-      )}
-    </WordAndSpaceContainer>
+            <WordComponent
+              key={`word-${word.originalIndex}-${word.pasteKey}`}
+              seekToWord={() => seekToWord(index)}
+              isPlaying={index === nowPlayingWordIndex}
+              isSelected={isSelected}
+              isSelectedLeftCap={
+                selectionSet.has(index) && !selectionSet.has(index - 1)
+              }
+              isSelectedRightCap={
+                selectionSet.has(index) && !selectionSet.has(index + 1)
+              }
+              selectedByClientWithIndex={selectedByClientWithIndex}
+              isSelectedByAnotherClientLeftCap={
+                isSelectedByAnotherClientLeftCap
+              }
+              isSelectedByAnotherClientRightCap={
+                isSelectedByAnotherClientRightCap
+              }
+              text={word.word}
+              confidence={word.confidence ?? 1}
+              index={index}
+              onMouseDown={onWordMouseDown(index)}
+              onMouseMove={() => onWordMouseMove(index)}
+              dragState={dragState}
+              isBeingDragged={isWordBeingDragged(index)}
+              mouse={isWordBeingDragged(index) ? mouse : mouseThrottled}
+              isDropBeforeActive={dropBeforeIndex === index}
+              isDropAfterActive={dropBeforeIndex === index + 1}
+              setDropBeforeIndex={setDropBeforeIndex}
+              cancelDrag={cancelDrag}
+              submitWordEdit={submitWordEdit}
+              isBeingEdited={editWord?.index === index}
+              editText={editWord?.text ?? null}
+              isInInactiveTake={isInInactiveTake}
+              isShowingConfidenceUnderlines={isShowingConfidenceUnderlines}
+            />
+            {index === transcription.words.length - 1 && (
+              <WordSpace
+                key="space-end"
+                isDropMarkerActive={
+                  dragState !== null &&
+                  dropBeforeIndex === transcription.words.length
+                }
+                isBetweenHighlightedWords={false}
+                highlightedByClientWithIndex={null}
+              />
+            )}
+          </Fragment>
+        )}
+      </WordAndSpaceContainer>
+    </Profiler>
   );
 };
 

--- a/src/renderer/components/Editor/WordOuterComponent.tsx
+++ b/src/renderer/components/Editor/WordOuterComponent.tsx
@@ -1,10 +1,9 @@
 import { Box, styled } from '@mui/material';
 import { MousePosition } from '@react-hook/mouse-position';
 import { ClientId } from 'collabTypes/collabShadowTypes';
-import React, { Fragment, Profiler, RefObject, useMemo } from 'react';
+import React, { Fragment, RefObject, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { ApplicationStore, EditWordState } from 'renderer/store/sharedHelpers';
-import profileWords from 'renderer/utils/profile';
 import { Word } from 'sharedTypes';
 import EditMarker from './EditMarker';
 import WordComponent, { WordPassThroughProps } from './WordComponent';

--- a/src/renderer/components/Editor/WordOuterComponent.tsx
+++ b/src/renderer/components/Editor/WordOuterComponent.tsx
@@ -1,9 +1,10 @@
 import { Box, styled } from '@mui/material';
 import { MousePosition } from '@react-hook/mouse-position';
 import { ClientId } from 'collabTypes/collabShadowTypes';
-import React, { Fragment, RefObject, useMemo } from 'react';
+import React, { Fragment, Profiler, RefObject, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { ApplicationStore, EditWordState } from 'renderer/store/sharedHelpers';
+import profileWords from 'renderer/utils/profile';
 import { Word } from 'sharedTypes';
 import EditMarker from './EditMarker';
 import WordComponent, { WordPassThroughProps } from './WordComponent';

--- a/src/renderer/components/Editor/WordSpace.tsx
+++ b/src/renderer/components/Editor/WordSpace.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import colors from 'renderer/colors';
 import { getColourForIndex } from 'renderer/utils/ui';
 
@@ -38,4 +39,4 @@ const WordSpace = ({
   );
 };
 
-export default WordSpace;
+export default React.memo(WordSpace);

--- a/src/renderer/pages/Project.tsx
+++ b/src/renderer/pages/Project.tsx
@@ -49,7 +49,6 @@ const ProjectPage = () => {
         pause,
         seekForward,
         seekBack,
-        seekToWord,
         setPlaybackTime
       ) => (
         <ResizeManager
@@ -92,10 +91,10 @@ const ProjectPage = () => {
                     <TranscriptionBlock
                       transcription={currentProject.transcription}
                       nowPlayingWordIndex={nowPlayingWordIndex}
-                      seekToWord={seekToWord}
                       blockWidth={
                         window.innerWidth - videoPreviewContainerWidth
                       }
+                      setPlaybackTime={setPlaybackTime}
                     />
                   )}
                 </Stack>

--- a/src/renderer/store/sharedHelpers.ts
+++ b/src/renderer/store/sharedHelpers.ts
@@ -9,6 +9,8 @@ import { OpQueueItem } from './opQueue/helpers';
 import { SelectionState } from './selection/helpers';
 import { UndoStack } from './undoStack/helpers';
 
+export type EditWordState = { index: number; text: string } | null;
+
 /**
  * The schema for the root-level application / redux store, containing the global app state.
  */
@@ -24,7 +26,7 @@ export interface ApplicationStore {
   shortcutsOpened: boolean;
   isUpdateTranscriptionAPIKeyOpened: boolean;
   // Index of word currently being edited, otherwise null
-  editWord: { index: number; text: string } | null;
+  editWord: EditWordState;
   // whether confidence underlines are currently visible
   isShowingConfidenceUnderlines: boolean;
   // Collab session state

--- a/src/renderer/utils/profile.ts
+++ b/src/renderer/utils/profile.ts
@@ -1,0 +1,15 @@
+let TOTAL_WORDS = 0;
+let TOTAL_TIME = 0;
+
+const profileWords: (label: string, type: string, time: number) => void = (
+  _,
+  _2,
+  timeTaken
+) => {
+  TOTAL_WORDS += 1;
+  TOTAL_TIME += timeTaken;
+
+  // console.log(TOTAL_TIME, TOTAL_WORDS);
+};
+
+export default profileWords;

--- a/src/renderer/utils/profile.ts
+++ b/src/renderer/utils/profile.ts
@@ -9,7 +9,7 @@ const profileWords: (label: string, type: string, time: number) => void = (
   TOTAL_WORDS += 1;
   TOTAL_TIME += timeTaken;
 
-  // console.log(TOTAL_TIME, TOTAL_WORDS);
+  console.log(TOTAL_TIME, TOTAL_WORDS);
 };
 
 export default profileWords;


### PR DESCRIPTION
Basically what this does is
- stops the transcription from re-rendering every single time the mouse moves (lol)
- memoises as much stuff as possible including entire components
- tries to prevent re renders by ensuring props don't change unless they have to
- only passes necessary info to word objects (e.g. rather than passing the entire selection state just pass whether the given word and its neighbours are selected)

The result is that it's actually usable on large-ish projects now e.g. this 700 word project:

Before (yuck):

https://user-images.githubusercontent.com/6735055/189466542-55508cd0-bcb9-45ee-ad10-62e25ee2254d.mov

After:

https://user-images.githubusercontent.com/6735055/189466544-04d2ea5f-22d2-4ebf-85d1-7865389075ba.mov

Dragging-a-word performance is still extremely meh but that will possibly be removed anyway so not focussing on it for now

Doc: https://docs.google.com/document/d/1W4lDUxVoTgD8n3yo6sPCi0Cu810vlnjoRi-dgSBmapI/edit

Fun fact - counting individual word renders, the old version easily renders / re-renders 10000 words from just a few seconds of usage. The new version renders only the words that are changed, so for this project it will render 700 words on load and another few hundred if you are copying/pasting things around - at least a 10x speed up, plus the actual word rendering is faster too due to memoisation as well.