### PR TITLE
Fix/cancel project modal styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Refer to the documents `tools/GENCODE_README.md` and `src/main/handlers/HANDLERS
 
 ## Additional steps you need to follow
 
-After the [audio extract PR](https://github.com/chloebrett/mlvet/pull/12) got merged you will now need to have a `demo-vdieo.mp4` video file under `assets/videos`
+After the [audio extract PR](https://github.com/chloebrett/mlvet/pull/12) got merged you will now need to have a `demo-video.mp4` video file under `assets/videos`
 
 Note:
 

--- a/src/renderer/components/ProjectCreation/CancelProjectModal.tsx
+++ b/src/renderer/components/ProjectCreation/CancelProjectModal.tsx
@@ -52,13 +52,13 @@ const CancelProjectModal = ({
   };
 
   const cancelProjectButton = (
-    <CustomButton color="primary" onClick={cancelProject}>
+    <CustomButton color="secondary" onClick={cancelProject}>
       Cancel Project
     </CustomButton>
   );
 
   const continueProjectButton = (
-    <CustomButton color="secondary" onClick={continueProject}>
+    <CustomButton color="primary" onClick={continueProject}>
       Continue
     </CustomButton>
   );


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/101803861/189570112-4841bd59-62d6-4b41-a156-a9dc01a347ba.png)

After:
![image](https://user-images.githubusercontent.com/101803861/189570131-c4a50227-36b9-46ab-b82a-8857837d1285.png)

Task #10 on the sheet Irmy posted: _"10. Cancel project screen should have continue highlighted + cancel project in grey"_