### PR TITLE
Added handling for cancel button, so it no longer goes to HOME page

### DIFF
--- a/src/renderer/navigation/returnToHome.ts
+++ b/src/renderer/navigation/returnToHome.ts
@@ -10,10 +10,14 @@ import store from 'renderer/store/store';
 const returnToHome: () => Promise<void> = async () => {
   const { currentProject } = store.getState();
   const saveChanges = 0;
+  const cancel = 2;
 
   if (currentProject === null) return;
 
   const userSelection = await window.electron.returnToHome(currentProject);
+
+  // if user cancels
+  if (userSelection === cancel) return;
 
   // if user wants to save unsaved changes
   if (userSelection === saveChanges) {


### PR DESCRIPTION
Task 4 on the sheet Irmy posted: _"Cancel button on go home doesn't work"_

Clicking cancel now correctly leaves the user in the project page.
Before this change it would go to the HOME page and the user would lose all changes to their project.

I assume this doesn't need a written test for. But lmk if you disagree,