### PR TITLE
Feature/edit word shortcut e

### DIFF
--- a/src/main/handlers/menu/setEditWordEnabled.ts
+++ b/src/main/handlers/menu/setEditWordEnabled.ts
@@ -1,0 +1,17 @@
+import { IpcContext } from '../../types';
+import setMenuButtonEnabled from '../helpers/menuUtils';
+
+type SetEditWordEnabled = (
+  ipcContext: IpcContext,
+  editEnabled: boolean
+) => void;
+
+const setEditWordEnabled: SetEditWordEnabled = async (
+  ipcContext,
+  editEnabled
+) => {
+  const { menu } = ipcContext;
+  setMenuButtonEnabled(menu, 'edit', 'editWord', editEnabled);
+};
+
+export default setEditWordEnabled;

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -27,6 +27,7 @@ import loadThumbnail from './handlers/media/thumbnailLoad';
 import transcribe from './handlers/media/transcribe';
 import requestTranscription from './handlers/media/transcriptionHandler';
 import setConfidenceLinesEnabled from './handlers/menu/setConfidenceLinesEnabled';
+import setEditWordEnabled from './handlers/menu/setEditWordEnabled';
 import setExportEnabled from './handlers/menu/setExportEnabled';
 import setFileRepresentation from './handlers/menu/setFileRepresentation';
 import setHomeEnabled from './handlers/menu/setHomeEnabled';
@@ -130,6 +131,10 @@ const initialiseIpcHandlers: (ipcContext: IpcContext) => void = (
     'set-confidence-lines-enabled',
     async (_event, menuItemEnabled) =>
       setConfidenceLinesEnabled(ipcContext, menuItemEnabled)
+  );
+
+  ipcMain.handle('set-edit-word-enabled', async (_event, editEnabled) =>
+    setEditWordEnabled(ipcContext, editEnabled)
   );
 
   ipcMain.handle('set-export-enabled', async (_event, exportEnabled) =>

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -147,6 +147,15 @@ export default class MenuBuilder {
   buildEditorAdditionalOptions(): MenuItemConstructorOptions[] {
     return [
       {
+        id: 'editWord',
+        label: 'Edit Word',
+        accelerator: 'E',
+        click: () => {
+          this.mainWindow.webContents.send('initiate-edit-word');
+        },
+        enabled: false, // by default, gets updated when selection changes
+      },
+      {
         id: 'mergeWords',
         label: 'Merge Words',
         accelerator: 'CommandOrControl+L', // 'M' already taken by window 'minimize'

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -55,6 +55,9 @@ contextBridge.exposeInMainWorld('electron', {
   setConfidenceLinesEnabled: (menuItemEnabled) =>
     ipcRenderer.invoke('set-confidence-lines-enabled', menuItemEnabled),
 
+  setEditWordEnabled: (editEnabled) =>
+    ipcRenderer.invoke('set-edit-word-enabled', editEnabled),
+
   setExportEnabled: (exportEnabled) =>
     ipcRenderer.invoke('set-export-enabled', exportEnabled),
 

--- a/src/renderer/StoreChangeObserver.tsx
+++ b/src/renderer/StoreChangeObserver.tsx
@@ -44,6 +44,10 @@ const StoreChangeObserver = () => {
     (store: ApplicationStore) => store.selection.self
   );
 
+  const isEditingWord = useSelector(
+    (store: ApplicationStore) => store.editWord?.index
+  );
+
   // Debounce the selection to limit network requests for sharing selection with other clients
   const [debouncedSelection, setDebouncedSelection] =
     useDebounce(selfSelection);
@@ -141,6 +145,14 @@ const StoreChangeObserver = () => {
       cutCopyDeleteEnabled
     );
   }, [clipboard, selfSelection]);
+
+  // Update edit word option in edit menu when selection is changed
+  useEffect(() => {
+    // Allow user to edit word if there is a single word selected and it is not already being edited
+    const editWordEnabled =
+      selfSelection.length === 1 && selfSelection[0] !== isEditingWord;
+    ipc.setEditWordEnabled(editWordEnabled);
+  }, [selfSelection, isEditingWord]);
 
   // Broadcast selection actions to other clients whenever the selection changes (this is debounced)
   useEffect(() => {

--- a/src/renderer/components/Editor/WordComponent.tsx
+++ b/src/renderer/components/Editor/WordComponent.tsx
@@ -4,7 +4,6 @@ import React, {
   useEffect,
   useRef,
   useMemo,
-  useState,
   useCallback,
 } from 'react';
 import { MousePosition } from '@react-hook/mouse-position';
@@ -12,7 +11,6 @@ import { pointIsInsideRect } from 'renderer/utils/geometry';
 import { useDispatch } from 'react-redux';
 import {
   editWordFinished,
-  editWordStarted,
   editWordUpdated,
 } from 'renderer/store/editWord/actions';
 import { TextField } from '@mui/material';
@@ -123,10 +121,6 @@ const WordComponent = ({
     }
   }, [isBeingEdited, inputRef]);
 
-  // For handling receiving double-clicks on a word
-  const [awaitingSecondClick, setAwaitingSecondClick] =
-    useState<boolean>(false);
-
   const ref = useRef<HTMLDivElement>(null);
 
   const { xPosition, yPosition, halfWidth, height, mouseX, mouseY } =
@@ -203,26 +197,11 @@ const WordComponent = ({
     index,
   ]);
 
-  const startEditing = useCallback(() => {
-    dispatch(editWordStarted(index, text));
-  }, [dispatch, index, text]);
-
   const onClick: MouseEventHandler<HTMLDivElement> = useCallback(
     (event) => {
       if (isInInactiveTake) {
         return;
       }
-
-      if (awaitingSecondClick) {
-        startEditing();
-        return;
-      }
-
-      setAwaitingSecondClick(true);
-      const DOUBLE_CLICK_THRESHOLD = 500; // ms
-      setTimeout(() => {
-        setAwaitingSecondClick(false);
-      }, DOUBLE_CLICK_THRESHOLD);
 
       setPlaybackTime(outputStartTime + 0.01); // add a small amount so the correct word is selected
       handleSelectWord(event, index);
@@ -231,15 +210,7 @@ const WordComponent = ({
       // which would clear the selection
       event.stopPropagation();
     },
-    [
-      isInInactiveTake,
-      awaitingSecondClick,
-      startEditing,
-      setAwaitingSecondClick,
-      setPlaybackTime,
-      outputStartTime,
-      index,
-    ]
+    [isInInactiveTake, setPlaybackTime, outputStartTime, index]
   );
 
   const highlightStyles: React.CSSProperties = useMemo(

--- a/src/renderer/editor/editWord.ts
+++ b/src/renderer/editor/editWord.ts
@@ -1,0 +1,19 @@
+import store from '../store/store';
+import { editWordStarted } from '../store/editWord/actions';
+import { getSelectionRanges } from './selection';
+
+const { dispatch } = store;
+
+const editWord = () => {
+  const words = store.getState().currentProject?.transcription?.words;
+  if (words === undefined) {
+    return;
+  }
+  const ranges = getSelectionRanges();
+  // Assume that only one word is selected, thus there is only one range and start/end indexes are the same
+  const index = ranges[0].startIndex;
+  const { word } = words[index];
+  dispatch(editWordStarted(index, word));
+};
+
+export default editWord;

--- a/src/renderer/editor/editWord.ts
+++ b/src/renderer/editor/editWord.ts
@@ -10,6 +10,9 @@ const editWord = () => {
     return;
   }
   const ranges = getSelectionRanges();
+  if (ranges.length === 0) {
+    return;
+  }
   // Assume that only one word is selected, thus there is only one range and start/end indexes are the same
   const index = ranges[0].startIndex;
   const { word } = words[index];

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -83,6 +83,8 @@ declare global {
 
       setConfidenceLinesEnabled: (menuItemEnabled: boolean) => void;
 
+      setEditWordEnabled: (editEnabled: boolean) => void;
+
       setExportEnabled: (exportEnabled: boolean) => void;
 
       setFileRepresentation: (

--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -8,6 +8,7 @@ const mockIpc = {
   setFileRepresentation: () => null,
   openProject: async () => null,
   setClipboardEnabled: async () => null,
+  setEditWordEnabled: async () => null,
   setMergeSplitEnabled: async () => null,
   setHomeEnabled: async () => null,
   setUndoRedoEnabled: async () => null,

--- a/src/renderer/ipcRegistration.ts
+++ b/src/renderer/ipcRegistration.ts
@@ -14,6 +14,7 @@ import openShortcuts from './navigation/openShortcuts';
 import openUpdateTranscriptionAPIKey from './navigation/openUpdateTranscriptionAPIKey';
 import registerKeyboardHandlers from './keyboardShortcutsRegistration';
 import toggleConfidenceUnderlines from './editor/toggleConfidenceUnderlines';
+import editWord from './editor/editWord';
 
 const IPC_RECEIVERS: Record<string, (...args: any[]) => void> = {
   // File actions
@@ -31,6 +32,7 @@ const IPC_RECEIVERS: Record<string, (...args: any[]) => void> = {
   'initiate-paste-text': pasteText,
   'initiate-delete-text': deleteText,
   'initiate-select-all': selectAllWords,
+  'initiate-edit-word': editWord,
   'initiate-merge-words': mergeWords,
   'initiate-split-word': splitWord,
   'initiate-undo': performUndo,


### PR DESCRIPTION
<!-- Notes!
    Please do not forget to:
        1. assign some one to review your pull request!
        2. did you include unit tests?
        3. did you merge develop into your branch?
        4. notify the #pr channel on slack!

    Feel free to remove the sections which you do not fill out
 -->

## Summary

Replaces the double click to edit word with a keyboard shortcut mapped to 'E'

<hr/>

### Why is this change needed?
Usability? idk tbh I prefer double clicking over this shortcut, but I think the best solution would be to add a right-click menu to the app and include it there. Might work on a right-click menu if I get time / PM approval
<hr/>

### What did you change?
the function to edit a word is now called from the edit drop down menu, or with the shortcut 'e'. This should only be able to be called when a single word is selected, and is not currently being edited

<hr/>

### Explain things which the reviewers are likely to need explaining. Remember that they didn’t write the code.
2 main new functions here. One to determine when the shortcut/menu option is available to be pressed/clicked ("setMenuButtonEnabled"), and one to actually perform the action when it is pressed/clicked. ("editWord")
<hr/>

### Testing details if applicable
Do I need tests for this? 
<hr/>


### OS

<!-- To select your OS. Place an 'x' within [ ]. eg. - [x] Linux -->

- [ ] Linux
- [X] MacOS
- [X] Windows
