### PR TITLE
fix hover css on take bracket

### DIFF
--- a/src/renderer/components/Editor/SquareBracket.tsx
+++ b/src/renderer/components/Editor/SquareBracket.tsx
@@ -6,24 +6,10 @@ import SquareBracketHover from './SquareBracketHover';
 interface Props {
   isLast: boolean;
   isTakeGroupOpened: boolean;
-  takeIndex: number;
-  takeGroupId: number;
 }
 
-const SquareBracket = ({
-  isLast,
-  isTakeGroupOpened,
-  takeIndex,
-  takeGroupId,
-}: Props) => {
+const SquareBracket = ({ isLast, isTakeGroupOpened }: Props) => {
   const bottomWidth = isLast || !isTakeGroupOpened ? '2px' : '0px';
-
-  const componentClassName = `squareBracket_${takeGroupId}_${takeIndex}`;
-  const componentSelector = '&:.'.concat('', componentClassName);
-
-  const hoverCss = { '&:hover': { [componentSelector]: { opacity: 0.5 } } };
-
-  console.log(hoverCss);
 
   const SquareBracketBox = styled(Box)({
     height: '60px',
@@ -35,12 +21,16 @@ const SquareBracket = ({
     borderTopWidth: '2px',
     borderBottomWidth: bottomWidth,
 
-    ...hoverCss,
+    '&:hover': {
+      '.squareBracket': {
+        opacity: 0.5,
+      },
+    },
   });
 
   return (
     <SquareBracketBox>
-      <SquareBracketHover isLast={isLast} compClassName={componentClassName} />
+      <SquareBracketHover isLast={isLast} />
     </SquareBracketBox>
   );
 };

--- a/src/renderer/components/Editor/SquareBracketHover.tsx
+++ b/src/renderer/components/Editor/SquareBracketHover.tsx
@@ -40,7 +40,6 @@ const HorizontalBracketBackground = ({
 
   return (
     <Box
-      // className={compClassName}
       className="squareBracket"
       id={idName}
       sx={{

--- a/src/renderer/components/Editor/SquareBracketHover.tsx
+++ b/src/renderer/components/Editor/SquareBracketHover.tsx
@@ -3,20 +3,15 @@ import colors from 'renderer/colors';
 
 interface Props {
   isLast: boolean;
-  compClassName: string;
-}
-
-interface VerticleBracketProps {
-  compClassName: string;
 }
 interface HorizontalBracketProps extends Props {
   top: boolean;
 }
 
-const VerticalBracketBackground = ({ compClassName }: VerticleBracketProps) => {
+const VerticalBracketBackground = () => {
   return (
     <Box
-      className={compClassName}
+      className="squareBracket"
       sx={{
         height: 'inherit',
         width: '8px',
@@ -36,7 +31,6 @@ const VerticalBracketBackground = ({ compClassName }: VerticleBracketProps) => {
 const HorizontalBracketBackground = ({
   top,
   isLast,
-  compClassName,
 }: HorizontalBracketProps) => {
   const bottomPixelOffset = isLast ? '14px' : '12px';
   const topBottomPosition = top
@@ -46,7 +40,8 @@ const HorizontalBracketBackground = ({
 
   return (
     <Box
-      className={compClassName}
+      // className={compClassName}
+      className="squareBracket"
       id={idName}
       sx={{
         height: '8px',
@@ -64,20 +59,12 @@ const HorizontalBracketBackground = ({
   );
 };
 
-const SquareBracketHover = ({ isLast, compClassName }: Props) => {
+const SquareBracketHover = ({ isLast }: Props) => {
   return (
     <>
-      <HorizontalBracketBackground
-        top
-        isLast={isLast}
-        compClassName={compClassName}
-      />
-      <VerticalBracketBackground compClassName={compClassName} />
-      <HorizontalBracketBackground
-        top={false}
-        isLast={isLast}
-        compClassName={compClassName}
-      />
+      <HorizontalBracketBackground top isLast={isLast} />
+      <VerticalBracketBackground />
+      <HorizontalBracketBackground top={false} isLast={isLast} />
     </>
   );
 };

--- a/src/renderer/components/Editor/TakeComponent.tsx
+++ b/src/renderer/components/Editor/TakeComponent.tsx
@@ -149,8 +149,6 @@ const TakeComponent = ({
               <SquareBracket
                 isLast={isLast}
                 isTakeGroupOpened={isTakeGroupOpened}
-                takeIndex={takeIndex}
-                takeGroupId={takeGroupId}
               />
               {takeWords.map((word, index, words) => {
                 const wordIndex = transcriptionIndex + index;


### PR DESCRIPTION
Here you go @Taz17 

Explanation:
- `&:` is for states (hover, focus, etc) not classnames or IDs
- "must be a child of the current element" is implied by the specificity of the styling, so there's no need for unique classnames. In general, if we did want unique classnames, we'd use IDs instead. But it's not needed here

So this allows us to drop a lot of the props since for styling purposes we don't actually need the take ID etc

Good article here https://css-tricks.com/the-sass-ampersand/