### PR TITLE
FEATURE/Paste Replaces Highlighted Selection

### DIFF
--- a/src/renderer/components/Editor/TakeGroupComponent.tsx
+++ b/src/renderer/components/Editor/TakeGroupComponent.tsx
@@ -75,8 +75,6 @@ const TakeGroupComponent = ({
         .map((take) => take.length)
         .reduce((acc, curr) => acc + curr, 0);
 
-    console.log(takeWords, takeIndex, chunkIndex, transcriptionIndex);
-
     return (
       <TakeComponent
         key={`take-${takeGroup.id}-${takeIndex}`}

--- a/src/renderer/editor/clipboard.ts
+++ b/src/renderer/editor/clipboard.ts
@@ -49,7 +49,6 @@ export const pasteText: () => void = () => {
   if (clipboard.length > 0) {
     pasteWord(range, clipboard);
   }
-  console.log(range, clipboard.length, clipboard);
 
   // TODO(chloe): should also seek to the start of the pasted text.
 };

--- a/src/renderer/editor/clipboard.ts
+++ b/src/renderer/editor/clipboard.ts
@@ -1,4 +1,3 @@
-import { getLengthOfRange } from 'renderer/utils/range';
 import { Word } from '../../sharedTypes';
 import { clipboardUpdated } from '../store/clipboard/actions';
 import store from '../store/store';
@@ -10,9 +9,13 @@ const { dispatch } = store;
 
 const pasteWord = (afterWordIndex: number, clipboard: Word[]) => {
   const { currentProject } = store.getState();
+  const wordIndexRange = {
+    startIndex: afterWordIndex,
+    endIndex: afterWordIndex,
+  }; // Need to convert number to index, to conform to param type.
 
   if (currentProject && currentProject.transcription) {
-    dispatchOp(makePasteWord(afterWordIndex, clipboard));
+    dispatchOp(makePasteWord(wordIndexRange, clipboard));
   }
 };
 

--- a/src/renderer/editor/clipboard.ts
+++ b/src/renderer/editor/clipboard.ts
@@ -1,4 +1,4 @@
-import { Word } from '../../sharedTypes';
+import { IndexRange, Word } from '../../sharedTypes';
 import { clipboardUpdated } from '../store/clipboard/actions';
 import store from '../store/store';
 import dispatchOp from '../store/dispatchOp';
@@ -7,15 +7,11 @@ import { makePasteWord } from '../store/transcriptionWords/ops/pasteWord';
 
 const { dispatch } = store;
 
-const pasteWord = (afterWordIndex: number, clipboard: Word[]) => {
+const pasteWord = (replaceRange: IndexRange, clipboard: Word[]) => {
   const { currentProject } = store.getState();
-  const wordIndexRange = {
-    startIndex: afterWordIndex,
-    endIndex: afterWordIndex,
-  }; // Need to convert number to index, to conform to param type.
 
   if (currentProject && currentProject.transcription) {
-    dispatchOp(makePasteWord(wordIndexRange, clipboard));
+    dispatchOp(makePasteWord(replaceRange, clipboard));
   }
 };
 

--- a/src/renderer/editor/clipboard.ts
+++ b/src/renderer/editor/clipboard.ts
@@ -1,3 +1,4 @@
+import { getLengthOfRange } from 'renderer/utils/range';
 import { Word } from '../../sharedTypes';
 import { clipboardUpdated } from '../store/clipboard/actions';
 import store from '../store/store';
@@ -45,16 +46,10 @@ export const pasteText: () => void = () => {
   const range = store.getState().selection.self;
   const { clipboard } = store.getState();
 
-  // Paste after the last word in the selection
-  const { startIndex, endIndex } = range;
-
-  if (clipboard.length && endIndex - startIndex > 1) {
-    // only replace if you're highlighting more than one word.
-    dispatchOp(makeDeleteSelection(range));
+  if (clipboard.length > 0) {
+    pasteWord(range, clipboard);
   }
-
-  // End index is exclusive, so subtract one to get the actual word to paste after
-  pasteWord(endIndex - 1, clipboard);
+  console.log(range, clipboard.length, clipboard);
 
   // TODO(chloe): should also seek to the start of the pasted text.
 };

--- a/src/renderer/editor/clipboard.ts
+++ b/src/renderer/editor/clipboard.ts
@@ -46,7 +46,12 @@ export const pasteText: () => void = () => {
   const { clipboard } = store.getState();
 
   // Paste after the last word in the selection
-  const { endIndex } = range;
+  const { startIndex, endIndex } = range;
+
+  if (clipboard.length && endIndex - startIndex > 1) {
+    // only replace if you're highlighting more than one word.
+    dispatchOp(makeDeleteSelection(range));
+  }
 
   // End index is exclusive, so subtract one to get the actual word to paste after
   pasteWord(endIndex - 1, clipboard);

--- a/src/renderer/store/transcription/__tests__/reducer.test.tsx
+++ b/src/renderer/store/transcription/__tests__/reducer.test.tsx
@@ -358,7 +358,10 @@ it('output duration should updated after copying and pasting new text', () => {
   const output = transcriptionReducer(transcript, {
     type: PASTE_WORD,
     payload: {
-      startIndex: 3,
+      range: {
+        startIndex: 3,
+        endIndex: 4,
+      },
       clipboard: [
         makeBasicWordSequential(0, 'a', false, undefined, 0, 0, 1, 0, 0.5),
         makeBasicWordSequential(
@@ -422,10 +425,14 @@ it('output duration should stay the same after copying and straight away undoing
     ],
   };
 
+  const range = {
+    startIndex: 3,
+    endIndex: 4,
+  };
   transcriptionReducer(transcript, {
     type: PASTE_WORD,
     payload: {
-      startIndex: 3,
+      range,
       clipboard: [
         makeBasicWordSequential(0, 'a', false, undefined, 0, 0, 1, 0, 0.5),
         makeBasicWordSequential(
@@ -446,7 +453,10 @@ it('output duration should stay the same after copying and straight away undoing
   const output = transcriptionReducer(transcript, {
     type: UNDO_PASTE_WORD,
     payload: {
-      startIndex: 3,
+      range: {
+        startIndex: 3,
+        endIndex: 4,
+      },
       clipboardLength: 2,
     },
   });

--- a/src/renderer/store/transcriptionWords/__tests__/reducer.test.tsx
+++ b/src/renderer/store/transcriptionWords/__tests__/reducer.test.tsx
@@ -89,6 +89,10 @@ describe('Transcription words reducer', () => {
   });
 
   it('should handle words being pasted', () => {
+    const range = {
+      startIndex: 2,
+      endIndex: 3,
+    };
     const output = transcriptionWordsReducer(
       [
         makeBasicWordSequential(0, 'a'),
@@ -103,7 +107,7 @@ describe('Transcription words reducer', () => {
       {
         type: PASTE_WORD,
         payload: {
-          startIndex: 2,
+          range,
           clipboard: [
             makeBasicWordSequential(5, 'f'),
             makeBasicWordSequential(6, 'g'),
@@ -129,6 +133,10 @@ describe('Transcription words reducer', () => {
   });
 
   it('should handle words that were already pasted, being pasted again', () => {
+    const range = {
+      startIndex: 2,
+      endIndex: 3,
+    };
     const output = transcriptionWordsReducer(
       [
         makeBasicWordSequential(0, 'a'),
@@ -146,7 +154,7 @@ describe('Transcription words reducer', () => {
       {
         type: PASTE_WORD,
         payload: {
-          startIndex: 2,
+          range,
           clipboard: [
             makeBasicWordSequential(5, 'f'),
             makeBasicWordSequential(6, 'g'),
@@ -175,6 +183,10 @@ describe('Transcription words reducer', () => {
   });
 
   it('should handle words being pasted even when some of the words on the clipboard were deleted', () => {
+    const range = {
+      startIndex: 2,
+      endIndex: 3,
+    };
     const output = transcriptionWordsReducer(
       [
         makeBasicWordSequential(0, 'a'),
@@ -189,7 +201,7 @@ describe('Transcription words reducer', () => {
       {
         type: PASTE_WORD,
         payload: {
-          startIndex: 2,
+          range,
           clipboard: [
             makeBasicWordSequential(5, 'f'),
             makeBasicWordSequential(6, 'g', true),
@@ -215,6 +227,10 @@ describe('Transcription words reducer', () => {
   });
 
   it('should handle words being pasted just after the start of the transcription', () => {
+    const range = {
+      startIndex: 0,
+      endIndex: 1,
+    };
     const output = transcriptionWordsReducer(
       [
         makeBasicWordSequential(0, 'a'),
@@ -229,7 +245,7 @@ describe('Transcription words reducer', () => {
       {
         type: PASTE_WORD,
         payload: {
-          startIndex: 0,
+          range,
           clipboard: [
             makeBasicWordSequential(5, 'f'),
             makeBasicWordSequential(6, 'g'),
@@ -255,6 +271,10 @@ describe('Transcription words reducer', () => {
   });
 
   it('should handle words being pasted to the end of the transcription', () => {
+    const range = {
+      startIndex: 7,
+      endIndex: 8,
+    };
     const output = transcriptionWordsReducer(
       [
         makeBasicWordSequential(0, 'a'),
@@ -269,7 +289,7 @@ describe('Transcription words reducer', () => {
       {
         type: PASTE_WORD,
         payload: {
-          startIndex: 7,
+          range,
           clipboard: [
             makeBasicWordSequential(3, 'd'),
             makeBasicWordSequential(4, 'e'),
@@ -295,6 +315,10 @@ describe('Transcription words reducer', () => {
   });
 
   it('should handle a paste being undone', () => {
+    const range = {
+      startIndex: 1,
+      endIndex: 2,
+    };
     const output = transcriptionWordsReducer(
       [
         makeBasicWordSequential(0, 'a'),
@@ -308,7 +332,7 @@ describe('Transcription words reducer', () => {
       {
         type: UNDO_PASTE_WORD,
         payload: {
-          startIndex: 1,
+          range,
           clipboardLength: 2,
         },
       }
@@ -324,6 +348,10 @@ describe('Transcription words reducer', () => {
   });
 
   it('should handle a paste being undone with various words deleted', () => {
+    const range = {
+      startIndex: 1,
+      endIndex: 2,
+    };
     const output = transcriptionWordsReducer(
       [
         makeBasicWordSequential(0, 'a', true),
@@ -337,7 +365,7 @@ describe('Transcription words reducer', () => {
       {
         type: UNDO_PASTE_WORD,
         payload: {
-          startIndex: 1,
+          range,
           clipboardLength: 2,
         },
       }
@@ -353,6 +381,10 @@ describe('Transcription words reducer', () => {
   });
 
   it('should handle a paste of multiple words with the same original index', () => {
+    const range = {
+      startIndex: 2,
+      endIndex: 3,
+    };
     const output = transcriptionWordsReducer(
       [
         makeBasicWordSequential(0, 'a'),
@@ -362,7 +394,7 @@ describe('Transcription words reducer', () => {
       {
         type: PASTE_WORD,
         payload: {
-          startIndex: 2,
+          range,
           clipboard: [
             makeBasicWordSequential(0, 'a'),
             makeBasicWordSequential(0, 'a', false, 1),

--- a/src/renderer/store/transcriptionWords/actions.ts
+++ b/src/renderer/store/transcriptionWords/actions.ts
@@ -48,19 +48,19 @@ export const undoSelectionDeleted: (
 });
 
 export const wordPasted: (
-  startIndex: number,
+  range: IndexRange,
   clipboard: Word[]
-) => Action<PasteWordsPayload> = (startIndex, clipboard) => ({
+) => Action<PasteWordsPayload> = (range, clipboard) => ({
   type: PASTE_WORD,
-  payload: { startIndex, clipboard },
+  payload: { range, clipboard },
 });
 
 export const undoWordPasted: (
-  startIndex: number,
+  range: IndexRange,
   clipboardLength: number
-) => Action<UndoPasteWordsPayload> = (startIndex, clipboardLength) => ({
+) => Action<UndoPasteWordsPayload> = (range, clipboardLength) => ({
   type: UNDO_PASTE_WORD,
-  payload: { startIndex, clipboardLength },
+  payload: { range, clipboardLength },
 });
 
 export const wordsMerged: (range: IndexRange) => Action<MergeWordsPayload> = (

--- a/src/renderer/store/transcriptionWords/opPayloads.ts
+++ b/src/renderer/store/transcriptionWords/opPayloads.ts
@@ -5,7 +5,7 @@ export interface DeleteSelectionPayload {
 }
 
 export interface PasteWordsPayload {
-  startIndex: number;
+  range: IndexRange;
   clipboard: Word[];
 }
 export interface RestoreSectionPayload {
@@ -15,7 +15,7 @@ export interface RestoreSectionPayload {
 export type UndoDeleteSelectionPayload = DeleteSelectionPayload;
 
 export interface UndoPasteWordsPayload {
-  startIndex: number;
+  range: IndexRange;
   clipboardLength: number;
 }
 

--- a/src/renderer/store/transcriptionWords/ops/pasteWord.ts
+++ b/src/renderer/store/transcriptionWords/ops/pasteWord.ts
@@ -3,11 +3,8 @@ import { IndexRange, Word } from 'sharedTypes';
 import {
   wordPasted,
   undoWordPasted,
-  selectionDeleted,
-  undoSelectionDeleted,
 } from 'renderer/store/transcriptionWords/actions';
 import { selectionRangeSetTo } from 'renderer/store/selection/actions';
-import { getLengthOfRange } from 'renderer/utils/range';
 import { PasteWordsPayload, UndoPasteWordsPayload } from '../opPayloads';
 
 export type PasteWordsOp = Op<PasteWordsPayload, UndoPasteWordsPayload>;

--- a/src/renderer/store/transcriptionWords/ops/pasteWord.ts
+++ b/src/renderer/store/transcriptionWords/ops/pasteWord.ts
@@ -18,34 +18,14 @@ export const makePasteWord: (
 ) => PasteWordsOp = (range, clipboard) => {
   const { endIndex } = range;
 
-  return getLengthOfRange(range) > 1
-    ? {
-        do: [
-          selectionDeleted(range),
-          wordPasted(range, clipboard),
-          selectionRangeSetTo({
-            startIndex: endIndex,
-            endIndex: endIndex + clipboard.length,
-          }),
-        ],
-        undo: [
-          undoWordPasted(range, clipboard.length),
-          undoSelectionDeleted(range),
-          selectionRangeSetTo(range),
-        ],
-      }
-    : {
-        do: [
-          wordPasted(range, clipboard),
-          selectionRangeSetTo({
-            startIndex: endIndex,
-            endIndex: endIndex + clipboard.length,
-          }),
-        ],
-        undo: [
-          undoWordPasted(range, clipboard.length),
-          undoSelectionDeleted(range),
-          selectionRangeSetTo(range),
-        ],
-      };
+  return {
+    do: [
+      wordPasted(range, clipboard),
+      selectionRangeSetTo({
+        startIndex: endIndex,
+        endIndex: endIndex + clipboard.length,
+      }),
+    ],
+    undo: [undoWordPasted(range, clipboard.length), selectionRangeSetTo(range)],
+  };
 };

--- a/src/renderer/store/transcriptionWords/reducer.ts
+++ b/src/renderer/store/transcriptionWords/reducer.ts
@@ -1,7 +1,7 @@
 import { Reducer } from 'react';
 import { mapInRange } from 'sharedUtils';
 import { Word } from 'sharedTypes';
-import { rangeLengthOne } from 'renderer/utils/range';
+import { getLengthOfRange, rangeLengthOne } from 'renderer/utils/range';
 import { markWordDeleted } from 'renderer/utils/words';
 import { Action } from '../action';
 import { mergeWords } from './helpers/mergeWordsHelper';
@@ -78,11 +78,13 @@ const transcriptionWordsReducer: Reducer<Word[], Action<any>> = (
 
     const suffix = words.slice(endIndex);
 
-    return mapInRange(
-      [...prefix, ...wordsToPaste, ...suffix],
-      markWordDeleted,
-      range
-    );
+    return getLengthOfRange(range) > 1
+      ? mapInRange(
+          [...prefix, ...wordsToPaste, ...suffix],
+          markWordDeleted,
+          range
+        )
+      : [...prefix, ...wordsToPaste, ...suffix];
   }
 
   if (action.type === UNDO_PASTE_WORD) {

--- a/src/renderer/utils/words.ts
+++ b/src/renderer/utils/words.ts
@@ -1,6 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 
 import { IndexRange, Word } from 'sharedTypes';
+import { getLengthOfRange } from './range';
 
 /**
  * Returns whether a list of words is in originalIndex order
@@ -15,10 +16,22 @@ export const isInOriginalOrder: (
       return true;
     }
 
+    // edge case, only one word
+    if (getLengthOfRange(range) === 1 || words.length === 1) {
+      return true;
+    }
+
+    const prevWordOriginalIndex =
+      index === 0 ? null : words[index - 1].originalIndex;
+    const nextWordOriginalIndex =
+      index === words.length - 1 ? null : words[index + 1].originalIndex;
+
     // word in order
     if (
-      (index === 0 && word.originalIndex === 0) ||
-      word.originalIndex === words[index - 1].originalIndex + 1
+      (prevWordOriginalIndex !== null &&
+        word.originalIndex === prevWordOriginalIndex + 1) ||
+      (nextWordOriginalIndex !== null &&
+        word.originalIndex === nextWordOriginalIndex - 1)
     ) {
       return true;
     }
@@ -28,3 +41,5 @@ export const isInOriginalOrder: (
   });
 
 export const markWordDeleted = (word: Word) => ({ ...word, deleted: true });
+
+export const markWordUndeleted = (word: Word) => ({ ...word, deleted: false });


### PR DESCRIPTION
## Summary

Pasting now replaces the highlighted selection of words, unless there is only a single word highlighted, i.e. "Nothing is highlighted"

This is because if nothing is highlighted, it exists in code as _the current word is highlighted_.

It should be easy to adjust the parameters for which pasting replaces the selection.

<hr/>

### OS

<!-- To select your OS. Place an 'x' within [ ]. eg. - [x] Linux -->

- [ ] Linux
- [ ] MacOS
- [X] Windows
