### PR TITLE
Change cut marker colour and make bigger

### DIFF
--- a/src/renderer/assets/EditMarkerSvg.tsx
+++ b/src/renderer/assets/EditMarkerSvg.tsx
@@ -1,7 +1,9 @@
+import colors from 'renderer/colors';
+
 const EditMarkerSvg = (): JSX.Element => {
   return (
     <svg
-      width="5"
+      width="7"
       height="15"
       viewBox="0 0 5 12"
       fill="none"
@@ -12,11 +14,11 @@ const EditMarkerSvg = (): JSX.Element => {
         y1="3"
         x2="2.5"
         y2="15"
-        stroke="#FAFBFC"
+        stroke={colors.yellow[500]}
         strokeDasharray="2 2"
+        strokeWidth="2"
       />
-      <path d="M2.5 5L0.334936 1.25L4.66506 1.25L2.5 5Z" fill="#FAFBFC" />
-      <path d="M2.5 5L0.334936 1.25L4.66506 1.25L2.5 5Z" fill="#FAFBFC" />
+      <path d="M 2.5 5 L -1 -1 L 6 -1 L 2.5 5 Z" fill={colors.yellow[500]} />
     </svg>
   );
 };


### PR DESCRIPTION


## Summary

purely aesthetic change to make cut markers bigger

<hr/>

Previous cut markers were too small in feedback

<hr/>

### What did you change?
the colour, width of the line and the svg code for the triangle

<hr/>

### Screenshots of UI changes, if any
<img width="91" alt="Screen Shot 2022-09-23 at 23 55 22" src="https://user-images.githubusercontent.com/69192205/191976815-35f2956f-9786-42ed-b21e-c45b7eabe3cd.png">

<hr/>

### OS

<!-- To select your OS. Place an 'x' within [ ]. eg. - [x] Linux -->

- [ ] Linux
- [x] MacOS
- [ ] Windows
