### PR TITLE
Feature/restore video preview redux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,3 @@ assets/thumbnails/thumbnail.png
 experiments/**/assets
 
 
-voskDLLs
-voskModel

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ assets/audio/audio.wav
 assets/thumbnails/thumbnail.png
 
 experiments/**/assets
+
+
+voskDLLs
+voskModel

--- a/src/renderer/components/Editor/EditMarker.tsx
+++ b/src/renderer/components/Editor/EditMarker.tsx
@@ -99,14 +99,20 @@ const EditMarker = ({
     setPopperText(deletedText);
   }, [getOriginalText, index, words, dispatch]);
 
-  const onClickAway = () => {
-    setPopperToggled(false);
+  const onClickAway = (event: React.PointerEvent<HTMLElement>) => {
+    // The property path does exist in this event.
+    // React does not have it within its PointerEvent interface
+    event.path.forEach((element: HTMLElement) => {
+      if (element.id === 'transcription-content') {
+        setPopperToggled(false);
 
-    dispatch(clearRangeOverride());
+        dispatch(clearRangeOverride());
 
-    dispatch(videoPlaying({ isPlaying: false, lastUpdated: new Date() }));
+        dispatch(videoPlaying({ isPlaying: false, lastUpdated: new Date() }));
 
-    dispatch(videoSeek({ time: 0, lastUpdated: new Date() }));
+        dispatch(videoSeek({ time: 0, lastUpdated: new Date() }));
+      }
+    });
   };
 
   const background = useMemo(() => {

--- a/src/renderer/components/Editor/EditMarker.tsx
+++ b/src/renderer/components/Editor/EditMarker.tsx
@@ -10,11 +10,13 @@ import colors from 'renderer/colors';
 import { Word } from 'sharedTypes';
 import {
   getOriginalWords,
+  getRestoreIndexRange,
   restoreOriginalSection,
 } from 'renderer/editor/restore';
 import { getColourForIndex } from 'renderer/utils/ui';
 import { ApplicationStore } from 'renderer/store/sharedHelpers';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+import { setRangeOverride } from 'renderer/store/playback/actions';
 import RestorePopover from './RestorePopover';
 import EditMarkerSvg from '../../assets/EditMarkerSvg';
 
@@ -41,6 +43,7 @@ const EditMarker = ({
 }: Props) => {
   const [popperToggled, setPopperToggled] = useState<boolean | null>(false);
   const [popperText, setPopperText] = useState<string | null>(null);
+  const dispatch = useDispatch();
 
   const markerRef = useRef<HTMLDivElement>(null);
 
@@ -70,15 +73,25 @@ const EditMarker = ({
 
   const getOriginalText = useCallback(() => {
     const originalWords = getOriginalWords(index, words);
-    const originalText = originalWords.map((w) => w.word).join(' ');
 
-    return originalText;
+    return originalWords;
   }, [index, words]);
 
   const onMarkerClick = useCallback(() => {
     setPopperToggled(true);
-    setPopperText(getOriginalText());
-  }, [setPopperToggled, setPopperText, getOriginalText]);
+
+    const deletedWords = getOriginalText();
+    const deletedText = deletedWords.map((w) => w.word).join(' ');
+
+    const rangeOverride = getRestoreIndexRange(
+      deletedWords[0].originalIndex,
+      deletedWords
+    );
+
+    dispatch(setRangeOverride(rangeOverride));
+
+    setPopperText(deletedText);
+  }, [setPopperToggled, setPopperText, getOriginalText, dispatch]);
 
   const background = useMemo(() => {
     if (isSelected) {

--- a/src/renderer/components/Editor/PlaybackManager.tsx
+++ b/src/renderer/components/Editor/PlaybackManager.tsx
@@ -8,6 +8,8 @@ import React, {
   useMemo,
   useState,
 } from 'react';
+import { useSelector } from 'react-redux';
+import { ApplicationStore } from 'renderer/store/sharedHelpers';
 import { RuntimeProject } from 'sharedTypes';
 import { bufferedWordDuration, isInInactiveTake } from 'sharedUtils';
 import { VideoPreviewControllerRef } from '../VideoPreview/VideoPreviewController';
@@ -41,6 +43,10 @@ const PlaybackManager = ({
   const [isPlaying, setIsPlaying] = useState(false);
   const [nowPlayingWordIndex, setNowPlayingWordIndex] = useState<number>(0);
 
+  const rangeOverride = useSelector(
+    (store: ApplicationStore) => store.playback.rangeOverride
+  );
+
   const play = useCallback(
     () => videoPreviewControllerRef?.current?.play(),
     [videoPreviewControllerRef]
@@ -73,6 +79,11 @@ const PlaybackManager = ({
       return;
     }
 
+    if (rangeOverride !== null) {
+      setNowPlayingWordIndex(-1);
+      return;
+    }
+
     const newPlayingWordIndex = currentProject.transcription.words.findIndex(
       (word) =>
         time >= word.outputStartTime &&
@@ -85,7 +96,12 @@ const PlaybackManager = ({
       setNowPlayingWordIndex(newPlayingWordIndex);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [time, currentProject?.transcription]);
+  }, [
+    time,
+    currentProject?.transcription,
+    rangeOverride,
+    setNowPlayingWordIndex,
+  ]);
 
   return useMemo(
     () =>

--- a/src/renderer/components/Editor/PlaybackManager.tsx
+++ b/src/renderer/components/Editor/PlaybackManager.tsx
@@ -79,6 +79,8 @@ const PlaybackManager = ({
       return;
     }
 
+    // When rangeOverride is not null that means we are playing a deleted take (by clicking on the edit marker)
+    // then there should be no highlighted word, thus nowPlayingWordIndex is set to -1
     if (rangeOverride !== null) {
       setNowPlayingWordIndex(-1);
       return;

--- a/src/renderer/components/VideoPreview/index.tsx
+++ b/src/renderer/components/VideoPreview/index.tsx
@@ -54,6 +54,17 @@ const VideoPreviewBase = ({ src }: Props, ref: Ref<VideoPreviewRef>) => {
         controls: {
           includeControls: [],
         },
+        keyboardShortcuts: {
+          keyMap: {
+            togglePause: [],
+            toggleFullscreen: '',
+            decreaseVolume: '',
+            increaseVolume: '',
+            skipBack: '',
+            skipForward: '',
+            toggleMute: '',
+          },
+        },
       }}
       initialPlaybackProps={{ isPaused: true }}
       onStreamStateChange={handleStreamStateChange}

--- a/src/renderer/editor/restore.ts
+++ b/src/renderer/editor/restore.ts
@@ -46,9 +46,9 @@ export const getOriginalWords: (startIndex: number, words: Word[]) => Word[] = (
 ) => {
   const restoreIndexRange = getRestoreIndexRange(startIndex, words);
 
-  const originalWords = [...words].splice(
+  const originalWords = words.slice(
     restoreIndexRange.startIndex,
-    restoreIndexRange.endIndex - restoreIndexRange.startIndex
+    restoreIndexRange.endIndex
   );
 
   return originalWords;

--- a/src/renderer/pages/Project.tsx
+++ b/src/renderer/pages/Project.tsx
@@ -46,10 +46,6 @@ const ProjectPage = () => {
         isPlaying,
         setIsPlaying,
         nowPlayingWordIndex,
-        play,
-        pause,
-        seekForward,
-        seekBack,
         setPlaybackTime
       ) => (
         <ResizeManager

--- a/src/renderer/pages/Project.tsx
+++ b/src/renderer/pages/Project.tsx
@@ -6,7 +6,7 @@ import VideoPreviewController, {
 } from 'renderer/components/VideoPreview/VideoPreviewController';
 import PlaybackManager from 'renderer/components/Editor/PlaybackManager';
 import ResizeManager from 'renderer/components/Editor/ResizeManager';
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import ResizeSlider from 'renderer/components/Editor/ResizeSlider';
 import ExportCard from 'renderer/components/ExportCard';
 import Scrubber from 'renderer/components/Scrubber';
@@ -33,6 +33,7 @@ const ProjectPage = () => {
   const projectPageLayoutRef = useRef<HTMLDivElement>(null);
   const videoPreviewContainerRef = useRef<HTMLDivElement>(null);
   const videoPreviewControllerRef = useRef<VideoPreviewControllerRef>(null);
+  const [outputVideoLength, setOutputVideoLength] = useState<number>(0);
 
   return (
     <PlaybackManager
@@ -108,11 +109,11 @@ const ProjectPage = () => {
                       setTime={setTime}
                       setIsPlaying={setIsPlaying}
                       ref={videoPreviewControllerRef}
+                      outputVideoLength={outputVideoLength}
+                      setOutputVideoLength={setOutputVideoLength}
                     />
                     <Scrubber
-                      totalDuration={
-                        currentProject?.transcription?.outputDuration ?? 0
-                      }
+                      totalDuration={outputVideoLength}
                       currentTimeSeconds={time}
                       onScrubberChange={setPlaybackTime}
                     />

--- a/src/renderer/store/playback/actions.ts
+++ b/src/renderer/store/playback/actions.ts
@@ -1,8 +1,11 @@
+import { IndexRange } from 'sharedTypes';
 import { Action } from '../action';
 
 export const VIDEO_PLAYING = 'VIDEO_PLAYING';
 export const VIDEO_SEEK = 'VIDEO_SEEK';
 export const VIDEO_SKIP = 'VIDEO_SKIP';
+export const SET_RANGE_OVERRIDE = 'SET_RANGE_OVERRIDE';
+export const CLEAR_RANGE_OVERRIDE = 'CLEAR_RANGE_OVERRIDE';
 
 export interface UpdatedPlaying {
   isPlaying: boolean;
@@ -18,6 +21,10 @@ export interface UpdatedTimeSkip {
   addtime: number;
   lastUpdated: Date;
   maxDuration: number;
+}
+
+export interface SetRangeOverridePayload {
+  rangeOverride: IndexRange;
 }
 
 export const videoPlaying: (
@@ -39,4 +46,16 @@ export const videoSkip: (
 ) => Action<UpdatedTimeSkip> = (timeState) => ({
   type: VIDEO_SKIP,
   payload: timeState,
+});
+
+export const setRangeOverride: (
+  rangeOverride: IndexRange
+) => Action<SetRangeOverridePayload> = (rangeOverride) => ({
+  type: SET_RANGE_OVERRIDE,
+  payload: { rangeOverride },
+});
+
+export const clearRangeOverride: () => Action<null> = () => ({
+  type: CLEAR_RANGE_OVERRIDE,
+  payload: null,
 });

--- a/src/renderer/store/playback/helpers.ts
+++ b/src/renderer/store/playback/helpers.ts
@@ -1,5 +1,8 @@
+import { IndexRange } from 'sharedTypes';
+
 export interface PlaybackState {
   isPlaying: boolean;
   time: number;
   lastUpdated: Date;
+  rangeOverride: IndexRange | null;
 }

--- a/src/renderer/store/playback/reducer.ts
+++ b/src/renderer/store/playback/reducer.ts
@@ -20,37 +20,35 @@ const playbackReducer: Reducer<ApplicationStore['playback'], Action<any>> = (
 ) => {
   if (action.type === VIDEO_PLAYING) {
     const playState = action.payload as UpdatedPlaying;
+    const { isPlaying, lastUpdated } = playState;
+
     return {
-      isPlaying: playState.isPlaying,
-      time: playback.time,
-      lastUpdated: playState.lastUpdated,
-      rangeOverride: playback.rangeOverride,
+      ...playback,
+      isPlaying,
+      lastUpdated,
     };
   }
 
   if (action.type === VIDEO_SEEK) {
     const timeState = action.payload as UpdatedTimeSeek;
+    const { time, lastUpdated } = timeState;
+
     return {
-      isPlaying: playback.isPlaying,
-      time: timeState.time,
-      lastUpdated: timeState.lastUpdated,
-      rangeOverride: playback.rangeOverride,
+      ...playback,
+      time,
+      lastUpdated,
     };
   }
 
   if (action.type === VIDEO_SKIP) {
     const timeState = action.payload as UpdatedTimeSkip;
+    const { addtime, lastUpdated, maxDuration } = timeState;
 
     if (!playback.isPlaying) {
       return {
-        isPlaying: playback.isPlaying,
-        time: clamp(
-          playback.time + timeState.addtime,
-          0,
-          timeState.maxDuration
-        ),
-        lastUpdated: timeState.lastUpdated,
-        rangeOverride: playback.rangeOverride,
+        ...playback,
+        time: clamp(playback.time + addtime, 0, maxDuration),
+        lastUpdated,
       };
     }
 
@@ -59,14 +57,9 @@ const playbackReducer: Reducer<ApplicationStore['playback'], Action<any>> = (
         (timeState.lastUpdated.getTime() - playback.lastUpdated.getTime()) /
         1000;
       return {
-        isPlaying: playback.isPlaying,
-        time: clamp(
-          playback.time + timeState.addtime + timeDifference,
-          0,
-          timeState.maxDuration
-        ),
+        ...playback,
+        time: clamp(playback.time + addtime + timeDifference, 0, maxDuration),
         lastUpdated: timeState.lastUpdated,
-        rangeOverride: playback.rangeOverride,
       };
     }
   }

--- a/src/renderer/store/playback/reducer.ts
+++ b/src/renderer/store/playback/reducer.ts
@@ -6,9 +6,12 @@ import {
   VIDEO_PLAYING,
   VIDEO_SEEK,
   VIDEO_SKIP,
+  SET_RANGE_OVERRIDE,
+  CLEAR_RANGE_OVERRIDE,
   UpdatedPlaying,
   UpdatedTimeSeek,
   UpdatedTimeSkip,
+  SetRangeOverridePayload,
 } from './actions';
 
 const playbackReducer: Reducer<ApplicationStore['playback'], Action<any>> = (
@@ -21,6 +24,7 @@ const playbackReducer: Reducer<ApplicationStore['playback'], Action<any>> = (
       isPlaying: playState.isPlaying,
       time: playback.time,
       lastUpdated: playState.lastUpdated,
+      rangeOverride: playback.rangeOverride,
     };
   }
 
@@ -30,6 +34,7 @@ const playbackReducer: Reducer<ApplicationStore['playback'], Action<any>> = (
       isPlaying: playback.isPlaying,
       time: timeState.time,
       lastUpdated: timeState.lastUpdated,
+      rangeOverride: playback.rangeOverride,
     };
   }
 
@@ -45,6 +50,7 @@ const playbackReducer: Reducer<ApplicationStore['playback'], Action<any>> = (
           timeState.maxDuration
         ),
         lastUpdated: timeState.lastUpdated,
+        rangeOverride: playback.rangeOverride,
       };
     }
 
@@ -60,8 +66,25 @@ const playbackReducer: Reducer<ApplicationStore['playback'], Action<any>> = (
           timeState.maxDuration
         ),
         lastUpdated: timeState.lastUpdated,
+        rangeOverride: playback.rangeOverride,
       };
     }
+  }
+
+  if (action.type === SET_RANGE_OVERRIDE) {
+    const { rangeOverride } = action.payload as SetRangeOverridePayload;
+
+    return {
+      ...playback,
+      rangeOverride,
+    };
+  }
+
+  if (action.type === CLEAR_RANGE_OVERRIDE) {
+    return {
+      ...playback,
+      rangeOverride: null,
+    };
   }
 
   return playback;

--- a/src/renderer/store/sharedHelpers.ts
+++ b/src/renderer/store/sharedHelpers.ts
@@ -62,5 +62,6 @@ export const initialStore: ApplicationStore = {
     isPlaying: false,
     time: 0,
     lastUpdated: new Date(),
+    rangeOverride: null,
   },
 };

--- a/src/transcriptProcessing/transcriptToCuts.ts
+++ b/src/transcriptProcessing/transcriptToCuts.ts
@@ -1,16 +1,27 @@
 import { updateOutputTimes } from './updateOutputTimes';
-import { Transcription, Cut } from '../sharedTypes';
+import { Transcription, Cut, IndexRange } from '../sharedTypes';
 import {
   bufferedWordDuration,
   roundToMs,
   isInInactiveTake,
 } from '../sharedUtils';
 
-const convertTranscriptToCuts = (transcript: Transcription): Array<Cut> => {
-  // filter out deleted words as well as words in inactive takes
-  const wordsNotYetUpdated = transcript.words.filter(
-    (word) => !word.deleted && !isInInactiveTake(word, transcript.takeGroups)
-  );
+const convertTranscriptToCuts = (
+  transcript: Transcription,
+  rangeOverride: IndexRange | null = null
+): Array<Cut> => {
+  const wordsNotYetUpdated =
+    // filter out deleted words as well as words in inactive takes
+    rangeOverride === null
+      ? transcript.words.filter(
+          (word) =>
+            !word.deleted && !isInInactiveTake(word, transcript.takeGroups)
+        )
+      : // keep deleted words when rangeOverride is specified
+        transcript.words.slice(
+          rangeOverride.startIndex,
+          rangeOverride.endIndex
+        );
 
   if (wordsNotYetUpdated.length === 0) {
     return [];


### PR DESCRIPTION
## Summary

When the user clicks on a deleted take it should then play the deleted take on the video preview with the following conditions:
1. Scrubber must play the deleted take (meaning 0 is the start of the take, and the right most section of the scrubber is the end of the deleted take)
2. Word highlight must not be displayed.

<hr/>

### Does it depend on any other changes/PRs?
Yes, Andys #274 
<hr/>

### Demo recording

https://user-images.githubusercontent.com/86769131/192126803-7108aa7d-4545-4217-92fe-21f265bcd56d.mp4


<hr/>

### OS

- [x] Linux
- [ ] MacOS
- [ ] Windows