### PR TITLE
Fix dialog cancel error

### DIFF
--- a/src/renderer/file/exportProject.ts
+++ b/src/renderer/file/exportProject.ts
@@ -14,7 +14,11 @@ const exportProject: (exportFormat: ExportFormat) => Promise<void> = async (
   // Don't export if we don't have a project open
   if (currentProject === null) return;
 
-  await ipc.exportProject(exportFormat, currentProject);
+  try {
+    await ipc.exportProject(exportFormat, currentProject);
+  } catch (err) {
+    console.error(err);
+  }
 };
 
 export default exportProject;

--- a/src/renderer/file/saveAsProject.ts
+++ b/src/renderer/file/saveAsProject.ts
@@ -28,7 +28,8 @@ const saveAsProject: () => Promise<void> = async () => {
   let filePath = '';
   try {
     filePath = await ipc.saveAsProject(newProject);
-  } catch {
+  } catch (err) {
+    console.error(err);
     return;
   }
 

--- a/src/renderer/file/saveAsProject.ts
+++ b/src/renderer/file/saveAsProject.ts
@@ -25,7 +25,12 @@ const saveAsProject: () => Promise<void> = async () => {
 
   // TODO(chloe): regenerate thumbnail and audio extract
 
-  const filePath = await ipc.saveAsProject(newProject);
+  let filePath = '';
+  try {
+    filePath = await ipc.saveAsProject(newProject);
+  } catch {
+    return;
+  }
 
   const savedFileNameWithExtension = await ipc.getFileNameWithExtension(
     filePath

--- a/src/renderer/file/saveProject.ts
+++ b/src/renderer/file/saveProject.ts
@@ -11,7 +11,12 @@ const saveProject: (shouldCloseAfter: boolean) => Promise<void> = async (
   // Don't save if we don't have a project open
   if (currentProject === null) return;
 
-  const filePath = await ipc.saveProject(currentProject);
+  let filePath = '';
+  try {
+    filePath = await ipc.saveProject(currentProject);
+  } catch {
+    return;
+  }
 
   const projectMetadata = await window.electron.retrieveProjectMetadata({
     ...currentProject,

--- a/src/renderer/file/saveProject.ts
+++ b/src/renderer/file/saveProject.ts
@@ -14,7 +14,8 @@ const saveProject: (shouldCloseAfter: boolean) => Promise<void> = async (
   let filePath = '';
   try {
     filePath = await ipc.saveProject(currentProject);
-  } catch {
+  } catch (err) {
+    console.error(err);
     return;
   }
 


### PR DESCRIPTION
<!-- Notes!
    Please do not forget to:
        1. assign some one to review your pull request!
        2. did you include unit tests?
        3. did you merge develop into your branch?
        4. notify the #pr channel on slack!

    Feel free to remove the sections which you do not fill out
 -->

## Summary

Added error handling to `export`, `save`, and `saveAs` dialog cancelation. 

To eliminate the error screen when canceling a dialog.

<hr/>

### What did you change?

When canceling a dialog it will just return and skip other calls. 

Not sure if this is the best way to handle the dialog cancelation.


<hr/>

### OS

<!-- To select your OS. Place an 'x' within [ ]. eg. - [x] Linux -->

- [x] Linux
- [ ] MacOS
- [x] Windows
