### PR TITLE
Feature/enter to restore prompt

### DIFF
--- a/src/renderer/components/Editor/RestorePopover.tsx
+++ b/src/renderer/components/Editor/RestorePopover.tsx
@@ -67,7 +67,7 @@ const RestorePopover = ({
             border: 0.5,
           }}
         >
-          <Stack>
+          <Stack alignItems="flex-end">
             <Typography style={{ color: colors.yellow[500] }} noWrap>
               {text}
             </Typography>

--- a/src/renderer/components/Editor/RestorePopover.tsx
+++ b/src/renderer/components/Editor/RestorePopover.tsx
@@ -2,6 +2,7 @@ import {
   Box,
   ClickAwayListener,
   Popper,
+  Stack,
   styled,
   Typography,
 } from '@mui/material';
@@ -57,7 +58,7 @@ const RestorePopover = ({
             whiteSpace: 'nowrap',
             textOverflow: 'ellipsis',
             overflow: 'hidden',
-            height: 38,
+            height: 50,
             maxWidth: width,
             padding: '8px',
             borderRadius: '5px',
@@ -65,9 +66,17 @@ const RestorePopover = ({
             border: 0.5,
           }}
         >
-          <Typography style={{ color: colors.yellow[500] }} noWrap>
-            {text}
-          </Typography>
+          <Stack>
+            <Typography style={{ color: colors.yellow[500] }} noWrap>
+              {text}
+            </Typography>
+            <Typography
+              variant="caption"
+              style={{ color: colors.grey[400], fontStyle: 'italic' }}
+            >
+              Enter to restore
+            </Typography>
+          </Stack>
         </Box>
       </StyledPopper>
     </ClickAwayListener>

--- a/src/renderer/components/Editor/RestorePopover.tsx
+++ b/src/renderer/components/Editor/RestorePopover.tsx
@@ -1,3 +1,4 @@
+import { SubdirectoryArrowLeft } from '@mui/icons-material';
 import {
   Box,
   ClickAwayListener,
@@ -58,7 +59,7 @@ const RestorePopover = ({
             whiteSpace: 'nowrap',
             textOverflow: 'ellipsis',
             overflow: 'hidden',
-            height: 50,
+            height: 53,
             maxWidth: width,
             padding: '8px',
             borderRadius: '5px',
@@ -74,7 +75,13 @@ const RestorePopover = ({
               variant="caption"
               style={{ color: colors.grey[400], fontStyle: 'italic' }}
             >
-              Enter to restore
+              Enter to restore&nbsp;
+              <SubdirectoryArrowLeft
+                sx={{
+                  fontSize: '12px',
+                  color: colors.grey[400],
+                }}
+              />
             </Typography>
           </Stack>
         </Box>


### PR DESCRIPTION
<!-- Notes!
    Please do not forget to:
        1. assign some one to review your pull request!
        2. did you include unit tests?
        3. did you merge develop into your branch?
        4. notify the #pr channel on slack!

    Feel free to remove the sections which you do not fill out
 -->

## Summary

Add the "enter to restore" text to the restore popover

<hr/>

### Why is this change needed?

The user can now understand how to interact with this popover which was previously difficult to understand

<hr/>

### What did you change?
Added text and MUI icon to restore popover
<hr/>

### Screenshots of UI changes, if any
<img width="480" alt="Screen Shot 2022-09-27 at 10 41 54" src="https://user-images.githubusercontent.com/69192205/192405456-6570c8d1-7a5d-4e59-9bdd-374ae61eb009.png">

<hr/>


### OS

<!-- To select your OS. Place an 'x' within [ ]. eg. - [x] Linux -->

- [ ] Linux
- [X] MacOS
- [ ] Windows
