### PR TITLE
Fix reportBug handler declaration and run gencode

### DIFF
--- a/src/main/handlers/misc/reportBug.ts
+++ b/src/main/handlers/misc/reportBug.ts
@@ -1,7 +1,9 @@
 import fetch from 'node-fetch';
 import { BUG_REPORT_API_URL } from '../../../constants';
 
-const reportBug = async (title: string, body: string) => {
+type ReportBug = (title: string, body: string) => Promise<number>;
+
+const reportBug: ReportBug = async (title, body) => {
   const response = await fetch(BUG_REPORT_API_URL, {
     method: 'POST',
     headers: {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -37,12 +37,12 @@ import setSelectSentenceEnabled from './handlers/menu/setSelectSentenceEnabled';
 import setUndoRedoEnabled from './handlers/menu/setUndoRedoEnabled';
 import getFileNameWithExtension from './handlers/misc/getFileNameWithExtension';
 import handleOsQuery from './handlers/misc/osQuery';
+import reportBug from './handlers/misc/reportBug';
 import setClipboardEnabled from './handlers/setClipboardEnabled';
 import closeWindow from './handlers/window/closeWindow';
 import promptSave from './handlers/window/promptSave';
 import returnToHome from './handlers/window/returnToHomeHandler';
 import showConfirmation from './handlers/window/showConfirmation';
-import reportBug from './handlers/misc/reportBug';
 // END GENERATED CODE PART 1
 
 const initialiseIpcHandlers: (ipcContext: IpcContext) => void = (
@@ -181,6 +181,10 @@ const initialiseIpcHandlers: (ipcContext: IpcContext) => void = (
 
   ipcMain.handle('handle-os-query', async () => handleOsQuery());
 
+  ipcMain.handle('report-bug', async (_event, title, body) =>
+    reportBug(title, body)
+  );
+
   ipcMain.handle(
     'set-clipboard-enabled',
     async (_event, cutEnabled, copyEnabled, pasteEnabled, deleteEnabled) =>
@@ -203,10 +207,6 @@ const initialiseIpcHandlers: (ipcContext: IpcContext) => void = (
 
   ipcMain.handle('show-confirmation', async (_event, message, detail) =>
     showConfirmation(ipcContext, message, detail)
-  );
-
-  ipcMain.handle('report-bug', async (_event, title, body) =>
-    reportBug(title, body)
   );
   // END GENERATED CODE PART 2
 };

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -89,6 +89,8 @@ contextBridge.exposeInMainWorld('electron', {
 
   handleOsQuery: () => ipcRenderer.invoke('handle-os-query'),
 
+  reportBug: (title, body) => ipcRenderer.invoke('report-bug', title, body),
+
   setClipboardEnabled: (cutEnabled, copyEnabled, pasteEnabled, deleteEnabled) =>
     ipcRenderer.invoke(
       'set-clipboard-enabled',
@@ -106,8 +108,6 @@ contextBridge.exposeInMainWorld('electron', {
 
   showConfirmation: (message, detail) =>
     ipcRenderer.invoke('show-confirmation', message, detail),
-
-  reportBug: (title, body) => ipcRenderer.invoke('report-bug', title, body),
   // END GENERATED CODE
 
   // Have to manually redefine, otherwise Electron nukes this since main->renderer comms is not a standard use case

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -113,6 +113,8 @@ declare global {
 
       handleOsQuery: () => Promise<OperatingSystems | null>;
 
+      reportBug: (title: string, body: string) => Promise<number>;
+
       setClipboardEnabled: (
         cutEnabled: boolean,
         copyEnabled: boolean,
@@ -127,8 +129,6 @@ declare global {
       returnToHome: (project: RuntimeProject) => Promise<number>;
 
       showConfirmation: (message: string, detail: string) => Promise<boolean>;
-
-      reportBug: (title: string, body: string) => Promise<number>;
       // END GENERATED CODE
 
       on: (


### PR DESCRIPTION
## Summary

Just a little fix to a handler function declaration so that `yarn gen` works again.

<hr/>

### What did you change?

Added a separate type declaration according to the following error given when `yarn gen` is run.

`Error: Error extracting type from handler in file reportBug.ts . Handler type must be declared separately from handler, with matching name in PascalCase. See existing handlers for examples.`
