### PR TITLE
Fix weird formatting with long project names in the new project model

### DIFF
--- a/src/renderer/components/ProjectCreation/RunTranscriptionView.tsx
+++ b/src/renderer/components/ProjectCreation/RunTranscriptionView.tsx
@@ -146,6 +146,7 @@ const RunTranscriptionView = ({ closeModal, nextView }: Props) => {
             overflow="hidden"
             textOverflow="ellipsis"
             variant="h1"
+            noWrap
             sx={{ color: colors.grey[400] }}
           >
             {projectName}


### PR DESCRIPTION
Title pretty much says it all. Just a small one line fix. 

**Before** 
<img width="711" alt="Screen Shot 2022-10-01 at 5 07 46 PM" src="https://user-images.githubusercontent.com/27614346/193397506-011d5382-aa81-4d10-b50c-1368685088ff.png">

**Now**
<img width="626" alt="Screen Shot 2022-10-01 at 5 07 35 PM" src="https://user-images.githubusercontent.com/27614346/193397595-23a8e946-b20e-42bc-a860-eb02bfd47722.png">
