### PR TITLE
FIX / Bugfix on autosave disallowing mp4 export

### DIFF
--- a/src/renderer/StoreChangeObserver.tsx
+++ b/src/renderer/StoreChangeObserver.tsx
@@ -218,7 +218,8 @@ const StoreChangeObserver = () => {
     if (
       currentProject &&
       currentProject.transcription &&
-      currentProject.projectFilePath
+      currentProject.projectFilePath &&
+      currentProject.isEdited
     ) {
       if (collab !== null && (collab as CollabClientSessionState).isHost)
         return; // Disallow autosave if you are not the host in collab


### PR DESCRIPTION
## Summary

Fixed a bug where mp4 export would not properly work after an autosave has executed.

<hr/>

### OS

<!-- To select your OS. Place an 'x' within [ ]. eg. - [x] Linux -->

- [ ] Linux
- [ ] MacOS
- [X] Windows
