### PR TITLE
Fix bug causing undos of nested deletes to restore more words than should be restored

### DIFF
--- a/src/collabServer/__tests__/SessionManager.test.ts
+++ b/src/collabServer/__tests__/SessionManager.test.ts
@@ -4,8 +4,7 @@ import { Socket } from 'socket.io-client';
 import { Transcription } from 'sharedTypes';
 import { UndoStack } from 'renderer/store/undoStack/helpers';
 import { CollabServerSessionState } from 'collabServer/types';
-import { rangeLengthOne } from 'renderer/utils/range';
-import { makeDeleteSelection } from 'renderer/store/transcriptionWords/ops/deleteSelection';
+import { makeDeleteWords } from 'renderer/store/transcriptionWords/ops/deleteSelection';
 import { ClientId, SessionCode } from 'collabTypes/collabShadowTypes';
 import SessionManager from '../SessionManager';
 
@@ -243,7 +242,7 @@ describe('SessionManager', () => {
     expect(guestSocketSpy).toBeCalledTimes(0);
 
     const actionId = 'abc';
-    const ops = [makeDeleteSelection(rangeLengthOne(0))];
+    const ops = [makeDeleteWords([0])];
 
     sessionManager.handleClientAction(actionId, ops, guestId, session.id);
 
@@ -261,7 +260,7 @@ describe('SessionManager', () => {
     expect(hostSocketSpy).toBeCalledTimes(0);
 
     const actionId = 'abc';
-    const ops = [makeDeleteSelection(rangeLengthOne(0))];
+    const ops = [makeDeleteWords([0])];
 
     sessionManager.handleClientAction(actionId, ops, guestId, session.id);
 
@@ -291,7 +290,7 @@ describe('SessionManager', () => {
     });
 
     const actionId = 'abc';
-    const ops = [makeDeleteSelection(rangeLengthOne(0))];
+    const ops = [makeDeleteWords([0])];
 
     expect(guestSocketSpy).toBeCalledTimes(0);
 
@@ -312,7 +311,7 @@ describe('SessionManager', () => {
 
     const firstActionId = 'abc';
     const secondActionId = 'def';
-    const ops = [makeDeleteSelection(rangeLengthOne(0))];
+    const ops = [makeDeleteWords([0])];
 
     // Guest pushes an action, it gets accepted
     sessionManager.handleClientAction(firstActionId, ops, guestId, session.id);
@@ -349,7 +348,7 @@ describe('SessionManager', () => {
 
     const firstActionId = 'abc';
     const secondActionId = 'def';
-    const ops = [makeDeleteSelection(rangeLengthOne(0))];
+    const ops = [makeDeleteWords([0])];
 
     // Guest pushes an action, it gets accepted
     sessionManager.handleClientAction(firstActionId, ops, guestId, session.id);

--- a/src/renderer/components/Editor/TranscriptionBlock.tsx
+++ b/src/renderer/components/Editor/TranscriptionBlock.tsx
@@ -6,7 +6,7 @@ import { IndexRange, TakeGroup, Transcription, Word } from 'sharedTypes';
 import dispatchOp from 'renderer/store/dispatchOp';
 import { makeCorrectWord } from 'renderer/store/transcriptionWords/ops/correctWord';
 import { editWordFinished } from 'renderer/store/editWord/actions';
-import { makeDeleteSelection } from 'renderer/store/transcriptionWords/ops/deleteSelection';
+import { makeDeleteWords } from 'renderer/store/transcriptionWords/ops/deleteSelection';
 import { emptyRange, rangeLengthOne } from 'renderer/utils/range';
 import {
   generateTranscriptionChunks,
@@ -117,7 +117,7 @@ const TranscriptionBlock = ({
 
     if (editWord.text === '') {
       // If the user edits a word to be empty, treat this as a delete action
-      dispatchOp(makeDeleteSelection(rangeLengthOne(index)));
+      dispatchOp(makeDeleteWords([index]));
     } else {
       // If the user edits a word, update the word then select it
       dispatchOp(makeCorrectWord(transcription.words, index, editWord.text));

--- a/src/renderer/editor/clipboard.ts
+++ b/src/renderer/editor/clipboard.ts
@@ -1,8 +1,9 @@
+import { excludeDeletedWords } from 'renderer/utils/range';
 import { IndexRange, Word } from '../../sharedTypes';
 import { clipboardUpdated } from '../store/clipboard/actions';
 import store from '../store/store';
 import dispatchOp from '../store/dispatchOp';
-import { makeDeleteSelection } from '../store/transcriptionWords/ops/deleteSelection';
+import { makeDeleteWords } from '../store/transcriptionWords/ops/deleteSelection';
 import { makePasteWord } from '../store/transcriptionWords/ops/pasteWord';
 
 const { dispatch } = store;
@@ -31,9 +32,22 @@ export const deleteText: () => void = () => {
 
   const { currentProject } = store.getState();
 
-  if (currentProject && currentProject.transcription) {
-    dispatchOp(makeDeleteSelection(range));
+  if (!currentProject?.transcription) {
+    return;
   }
+
+  const words = currentProject.transcription.words.slice(
+    range.startIndex,
+    range.endIndex
+  );
+
+  const indices = excludeDeletedWords(range, words);
+
+  if (indices.length === 0) {
+    return;
+  }
+
+  dispatchOp(makeDeleteWords(indices));
 };
 
 export const cutText: () => void = () => {

--- a/src/renderer/store/currentProject/reducer.ts
+++ b/src/renderer/store/currentProject/reducer.ts
@@ -12,12 +12,12 @@ import transcriptionReducer from '../transcription/reducer';
 import { TRANSCRIPTION_CREATED } from '../transcription/actions';
 import {
   CORRECT_WORD,
-  DELETE_SELECTION,
+  DELETE_WORDS,
   MERGE_WORDS,
   PASTE_WORD,
   UNDO_CORRECT_WORD,
   SPLIT_WORD,
-  UNDO_DELETE_SELECTION,
+  UNDO_DELETE_WORDS,
   UNDO_MERGE_WORDS,
   UNDO_PASTE_WORD,
   UNDO_SPLIT_WORD,
@@ -92,8 +92,8 @@ const currentProjectReducer: Reducer<
   if (
     [
       TRANSCRIPTION_CREATED,
-      DELETE_SELECTION,
-      UNDO_DELETE_SELECTION,
+      DELETE_WORDS,
+      UNDO_DELETE_WORDS,
       PASTE_WORD,
       UNDO_PASTE_WORD,
       CORRECT_WORD,

--- a/src/renderer/store/transcription/__tests__/reducer.test.tsx
+++ b/src/renderer/store/transcription/__tests__/reducer.test.tsx
@@ -1,9 +1,9 @@
 import { Word } from 'sharedTypes';
 import { TRANSCRIPTION_CREATED } from 'renderer/store/transcription/actions';
 import {
-  DELETE_SELECTION,
+  DELETE_WORDS,
   PASTE_WORD,
-  UNDO_DELETE_SELECTION,
+  UNDO_DELETE_WORDS,
   UNDO_PASTE_WORD,
 } from 'renderer/store/transcriptionWords/actions';
 import { makeBasicWord } from 'sharedUtils';
@@ -104,12 +104,9 @@ it('output duration should be updated after deleting words', () => {
   };
 
   const deleteOutput = transcriptionReducer(transcript, {
-    type: DELETE_SELECTION,
+    type: DELETE_WORDS,
     payload: {
-      range: {
-        startIndex: 1,
-        endIndex: 3,
-      },
+      indices: [1, 2],
     },
   });
 
@@ -190,22 +187,16 @@ it('output duration should be the same as original when deleting and straight af
   };
 
   transcriptionReducer(transcript, {
-    type: DELETE_SELECTION,
+    type: DELETE_WORDS,
     payload: {
-      range: {
-        startIndex: 1,
-        endIndex: 3,
-      },
+      indices: [1, 2],
     },
   });
 
   const undoOutput = transcriptionReducer(transcript, {
-    type: UNDO_DELETE_SELECTION,
+    type: UNDO_DELETE_WORDS,
     payload: {
-      range: {
-        startIndex: 1,
-        endIndex: 3,
-      },
+      indices: [1, 2],
     },
   });
 
@@ -248,12 +239,9 @@ it('output duration should be 0 after deleting all words', () => {
   };
 
   const deleteOutput = transcriptionReducer(transcript, {
-    type: DELETE_SELECTION,
+    type: DELETE_WORDS,
     payload: {
-      range: {
-        startIndex: 0,
-        endIndex: 4,
-      },
+      indices: [0, 1, 2, 3],
     },
   });
 
@@ -302,12 +290,9 @@ it('output duration should calculated from last non deleted word (not always las
   };
 
   const deleteOutput = transcriptionReducer(transcript, {
-    type: DELETE_SELECTION,
+    type: DELETE_WORDS,
     payload: {
-      range: {
-        startIndex: 2,
-        endIndex: 4,
-      },
+      indices: [2, 3],
     },
   });
 

--- a/src/renderer/store/transcription/reducer.ts
+++ b/src/renderer/store/transcription/reducer.ts
@@ -5,11 +5,11 @@ import { Action } from '../action';
 import transcriptionWordsReducer from '../transcriptionWords/reducer';
 import { TRANSCRIPTION_CREATED } from './actions';
 import {
-  DELETE_SELECTION,
+  DELETE_WORDS,
   MERGE_WORDS,
   PASTE_WORD,
   SPLIT_WORD,
-  UNDO_DELETE_SELECTION,
+  UNDO_DELETE_WORDS,
   UNDO_MERGE_WORDS,
   UNDO_PASTE_WORD,
   CORRECT_WORD,
@@ -41,8 +41,8 @@ const transcriptionReducer: Reducer<Transcription | null, Action<any>> = (
   // Delegate words-related actions to words reducer
   if (
     [
-      DELETE_SELECTION,
-      UNDO_DELETE_SELECTION,
+      DELETE_WORDS,
+      UNDO_DELETE_WORDS,
       PASTE_WORD,
       UNDO_PASTE_WORD,
       MERGE_WORDS,

--- a/src/renderer/store/transcriptionWords/__tests__/reducer.test.tsx
+++ b/src/renderer/store/transcriptionWords/__tests__/reducer.test.tsx
@@ -1,9 +1,9 @@
 import { Word } from 'sharedTypes';
 import {
-  DELETE_SELECTION,
+  DELETE_WORDS,
   PASTE_WORD,
   RESTORE_SECTION,
-  UNDO_DELETE_SELECTION,
+  UNDO_DELETE_WORDS,
   UNDO_PASTE_WORD,
   UNDO_RESTORE_SECTION,
 } from '../actions';
@@ -40,12 +40,9 @@ describe('Transcription words reducer', () => {
         makeBasicWordSequential(4, 'e'),
       ],
       {
-        type: DELETE_SELECTION,
+        type: DELETE_WORDS,
         payload: {
-          range: {
-            startIndex: 1,
-            endIndex: 3,
-          },
+          indices: [1, 2],
         },
       }
     );
@@ -69,12 +66,9 @@ describe('Transcription words reducer', () => {
         makeBasicWordSequential(4, 'e', true),
       ],
       {
-        type: UNDO_DELETE_SELECTION,
+        type: UNDO_DELETE_WORDS,
         payload: {
-          range: {
-            startIndex: 2,
-            endIndex: 5,
-          },
+          indices: [2, 3, 4],
         },
       }
     );

--- a/src/renderer/store/transcriptionWords/actions.ts
+++ b/src/renderer/store/transcriptionWords/actions.ts
@@ -15,8 +15,8 @@ import {
   UndoSplitWordPayload,
 } from './opPayloads';
 
-export const DELETE_SELECTION = 'DELETE_SELECTION';
-export const UNDO_DELETE_SELECTION = 'UNDO_DELETE_SELECTION';
+export const DELETE_WORDS = 'DELETE_WORDS';
+export const UNDO_DELETE_WORDS = 'UNDO_DELETE_WORDS';
 
 export const PASTE_WORD = 'PASTE_WORD';
 export const UNDO_PASTE_WORD = 'UNDO_PASTE_WORD';
@@ -34,17 +34,17 @@ export const RESTORE_SECTION = 'RESTORE_SECTION';
 export const UNDO_RESTORE_SECTION = 'UNDO_RESTORE_SECTION';
 
 export const selectionDeleted: (
-  range: IndexRange
-) => Action<DeleteSelectionPayload> = (range) => ({
-  type: DELETE_SELECTION,
-  payload: { range },
+  indices: number[]
+) => Action<DeleteSelectionPayload> = (indices) => ({
+  type: DELETE_WORDS,
+  payload: { indices },
 });
 
 export const undoSelectionDeleted: (
-  range: IndexRange
-) => Action<UndoDeleteSelectionPayload> = (range) => ({
-  type: UNDO_DELETE_SELECTION,
-  payload: { range },
+  indices: number[]
+) => Action<UndoDeleteSelectionPayload> = (indices) => ({
+  type: UNDO_DELETE_WORDS,
+  payload: { indices },
 });
 
 export const wordPasted: (

--- a/src/renderer/store/transcriptionWords/opPayloads.ts
+++ b/src/renderer/store/transcriptionWords/opPayloads.ts
@@ -1,7 +1,7 @@
 import { IndexRange, Word } from '../../../sharedTypes';
 
 export interface DeleteSelectionPayload {
-  range: IndexRange;
+  indices: number[];
 }
 
 export interface PasteWordsPayload {

--- a/src/renderer/store/transcriptionWords/ops/deleteSelection.ts
+++ b/src/renderer/store/transcriptionWords/ops/deleteSelection.ts
@@ -1,8 +1,8 @@
 import { Op } from 'renderer/store/undoStack/helpers';
 import { IndexRange } from 'sharedTypes';
 import {
-  selectionDeleted,
-  undoSelectionDeleted,
+  selectionDeleted as wordsDeleted,
+  undoSelectionDeleted as undoWordsDeleted,
 } from 'renderer/store/transcriptionWords/actions';
 import {
   selectionCleared,
@@ -18,9 +18,29 @@ export type DeleteSelectionOp = Op<
   UndoDeleteSelectionPayload
 >;
 
-export const makeDeleteSelection: (range: IndexRange) => DeleteSelectionOp = (
-  range
-) => ({
-  do: [selectionDeleted(range), selectionCleared()],
-  undo: [undoSelectionDeleted(range), selectionRangeSetTo(range)],
-});
+/**
+ * Makes an op to delete the words with the given indices.
+ * Indices are given instead of a range so that already-deleted
+ * words can be excluded.
+ * The indices given must be in ascending order.
+ * The list of indices cannot be empty.
+ * On undo, the selection will be restored to the maximal range of the indices.
+ * @returns
+ */
+export const makeDeleteWords: (indices: number[]) => DeleteSelectionOp = (
+  indices
+) => {
+  // Selection range containing all the indices (assuming they are
+  // in ascending order), plus possibly other values if the indices
+  // were non-contiguous. This is because a selection must be contiguous
+  // but the words to delete aren't necessarily contiguous.
+  const selectionRange: IndexRange = {
+    startIndex: indices[0],
+    endIndex: indices[indices.length - 1] + 1,
+  };
+
+  return {
+    do: [wordsDeleted(indices), selectionCleared()],
+    undo: [undoWordsDeleted(indices), selectionRangeSetTo(selectionRange)],
+  };
+};

--- a/src/renderer/store/transcriptionWords/reducer.ts
+++ b/src/renderer/store/transcriptionWords/reducer.ts
@@ -1,5 +1,5 @@
 import { Reducer } from 'react';
-import { mapInRange } from 'sharedUtils';
+import { mapInRange, mapWithIndices } from 'sharedUtils';
 import { Word } from 'sharedTypes';
 import { getLengthOfRange, rangeLengthOne } from 'renderer/utils/range';
 import { markWordDeleted, markWordUndeleted } from 'renderer/utils/words';
@@ -8,13 +8,13 @@ import { mergeWords } from './helpers/mergeWordsHelper';
 import { splitWord } from './helpers/splitWordHelper';
 import {
   CORRECT_WORD,
-  DELETE_SELECTION,
+  DELETE_WORDS,
   MERGE_WORDS,
   PASTE_WORD,
   RESTORE_SECTION,
   SPLIT_WORD,
   UNDO_CORRECT_WORD,
-  UNDO_DELETE_SELECTION,
+  UNDO_DELETE_WORDS,
   UNDO_MERGE_WORDS,
   UNDO_PASTE_WORD,
   UNDO_SPLIT_WORD,
@@ -41,21 +41,16 @@ const transcriptionWordsReducer: Reducer<Word[], Action<any>> = (
   words = [],
   action
 ) => {
-  if (action.type === DELETE_SELECTION) {
-    const { range } = action.payload as DeleteSelectionPayload;
+  if (action.type === DELETE_WORDS) {
+    const { indices } = action.payload as DeleteSelectionPayload;
 
-    return mapInRange(words, markWordDeleted, range);
+    return mapWithIndices(words, markWordDeleted, indices);
   }
 
-  if (action.type === UNDO_DELETE_SELECTION) {
-    const { range } = action.payload as UndoDeleteSelectionPayload;
+  if (action.type === UNDO_DELETE_WORDS) {
+    const { indices } = action.payload as UndoDeleteSelectionPayload;
 
-    const markUndeleted = (word: Word) => ({
-      ...word,
-      deleted: false,
-    });
-
-    return mapInRange(words, markUndeleted, range);
+    return mapWithIndices(words, markWordUndeleted, indices);
   }
 
   if (action.type === PASTE_WORD) {

--- a/src/renderer/utils/range.ts
+++ b/src/renderer/utils/range.ts
@@ -1,4 +1,4 @@
-import { IndexRange } from 'sharedTypes';
+import { IndexRange, Word } from 'sharedTypes';
 
 /**
  * Helper for making IndexRanges with a size of one, e.g. a single word
@@ -27,3 +27,21 @@ export const areRangesEqual: (
 ) => boolean = (rangeOne, rangeTwo) =>
   rangeOne.startIndex === rangeTwo.startIndex &&
   rangeOne.endIndex === rangeTwo.endIndex;
+
+/**
+ * Takes a range and a list of the words in that range,
+ * and builds a list of indices containing only the indices of
+ * words in that range that are not deleted.
+ */
+export const excludeDeletedWords: (
+  range: IndexRange,
+  wordsInRange: Word[]
+) => number[] = (range, wordsInRange) => {
+  const indices = [];
+  for (let i = range.startIndex; i < range.endIndex; i += 1) {
+    if (!wordsInRange[i - range.startIndex].deleted) {
+      indices.push(i);
+    }
+  }
+  return indices;
+};

--- a/src/sharedUtils.ts
+++ b/src/sharedUtils.ts
@@ -74,6 +74,26 @@ export const mapInRange: <T>(
 };
 
 /**
+ * Maps the values of a list using a given map function,
+ * but only for those values with given indices.
+ * Values outside of the given indices will be unaltered.
+ * @returns the mapped list
+ */
+export const mapWithIndices: <T>(
+  list: T[],
+  mapCallback: MapCallback<T, T>,
+  indices: number[]
+) => T[] = (list, mapCallback, indices) => {
+  const listNew = [...list];
+
+  indices.forEach((index) => {
+    listNew[index] = mapCallback(list[index], index, list);
+  });
+
+  return listNew;
+};
+
+/**
  * For testing - makes a word with any desired fields overridden
  * @param override - any fields to override
  * @returns


### PR DESCRIPTION
Resolves #292 

- See bug description - basically, fixes that bug
- Renames `DELETE_SELECTION` to `DELETE_WORDS` as it is a better descriptor of what the action does
- Also updates tests accordingly

Implementation details:
- "delete words" operations are now expressed as a list of indices to delete rather than a single range. The selection is still a single range / contiguous. Using indices allows us to exclude words that are already deleted from the range to delete.

This allows deletions of arbitrary depth (i.e. deletions where the selection contains sections that were already deleted by a previous delete) to "just work" - see the demo below.

Demo:

https://user-images.githubusercontent.com/6735055/193451799-e097e312-81ea-45dc-9bd0-f00e747837e4.mov

