### PR TITLE
fix: playback highlight mismatch

### DIFF
--- a/src/renderer/components/VideoPreview/VideoPreviewController.tsx
+++ b/src/renderer/components/VideoPreview/VideoPreviewController.tsx
@@ -101,7 +101,6 @@ const VideoPreviewControllerBase = (
   };
 
   const resetClockRef = () => {
-    clockRef.current.hasRunBefore = false;
     clockRef.current.isRunning = false;
     clockRef.current.intervalRef = null;
     clockRef.current.prevIntervalEndTime = getPerformanceTime();

--- a/src/renderer/components/VideoPreview/VideoPreviewController.tsx
+++ b/src/renderer/components/VideoPreview/VideoPreviewController.tsx
@@ -15,7 +15,6 @@ import { Buffer } from 'buffer';
 import VideoPreview, { VideoPreviewRef } from '.';
 
 export interface Clock {
-  hasRunBefore: boolean;
   time: number;
   isRunning: boolean;
   intervalRef: null | any;
@@ -68,7 +67,6 @@ const VideoPreviewControllerBase = (
     clamp(time, 0, outputVideoLength.current);
 
   const clockRef = useRef<Clock>({
-    hasRunBefore: false,
     isRunning: false,
     intervalRef: null,
     prevIntervalEndTime: getPerformanceTime(),
@@ -128,8 +126,7 @@ const VideoPreviewControllerBase = (
 
   // Start timer (setInterval)
   const startTimer = () => {
-    if (!clockRef.current.hasRunBefore) {
-      clockRef.current.hasRunBefore = true;
+    if (clockRef.current.time === 0) {
       clockRef.current.prevIntervalEndTime = getPerformanceTime();
       clockRef.current.intervalStartTime = getPerformanceTime();
     }


### PR DESCRIPTION
### Issue

Issue: https://github.com/chloebrett/mlvet/issues/344

Issue first mentioned here: https://github.com/chloebrett/mlvet/pull/333#issuecomment-1264562456

### Testing details if applicable

Open a project and click half way through then click play. Highlighting and audio should match up.

<hr/>

### OS

<!-- To select your OS. Place an 'x' within [ ]. eg. - [x] Linux -->

- [x] Linux
- [x] MacOS
- [x] Windows (tested by Hugh)
