### PR TITLE
fix: add `cursor: 'pointer'` on hover

### DIFF
--- a/src/renderer/components/ProjectCreation/TranscriptionChoiceButton.tsx
+++ b/src/renderer/components/ProjectCreation/TranscriptionChoiceButton.tsx
@@ -57,6 +57,7 @@ const TranscriptionChoiceButton = ({
         border: `1px solid ${colors.grey[600]}`,
         borderRadius: '5px',
         '&:hover': {
+          cursor: 'pointer',
           borderColor: colors.yellow[500],
           transition: 'border-color 0.14s ease-in-out',
           '#choice-button-icon': {


### PR DESCRIPTION
Fixes: https://github.com/chloebrett/mlvet/issues/346

Taking a screenshot on linux hides the cursor, so you really have to trust me