### PR TITLE
Feature/download model time remaining

### DIFF
--- a/src/main/handlers/file/transcriptionConfig/downloadModel.ts
+++ b/src/main/handlers/file/transcriptionConfig/downloadModel.ts
@@ -81,11 +81,11 @@ const calculateDownloadProgressWeights = (
   shouldDownloadModel: boolean
 ) => {
   if (shouldDownloadLibs && shouldDownloadModel) {
-    if (getModelUrl() === MODEL_SML_URL) return createWeights(0.45, 0.53);
-    return createWeights(0.02, 0.94);
+    if (getModelUrl() === MODEL_SML_URL) return createWeights(0.36, 0.63);
+    return createWeights(0.02, 0.97);
   }
-  if (shouldDownloadLibs) return createWeights(0.96, 0);
-  if (shouldDownloadModel) return createWeights(0, 0.96);
+  if (shouldDownloadLibs) return createWeights(0.99, 0);
+  if (shouldDownloadModel) return createWeights(0, 0.99);
   return createWeights(0, 0);
 };
 

--- a/src/main/handlers/file/transcriptionConfig/downloadModel.ts
+++ b/src/main/handlers/file/transcriptionConfig/downloadModel.ts
@@ -81,12 +81,11 @@ const calculateDownloadProgressWeights = (
   shouldDownloadModel: boolean
 ) => {
   if (shouldDownloadLibs && shouldDownloadModel) {
-    if (process.platform === OperatingSystems.LINUX)
-      return createWeights(0.5, 0.5);
-    return createWeights(0.1, 0.9);
+    if (getModelUrl() === MODEL_SML_URL) return createWeights(0.45, 0.53);
+    return createWeights(0.02, 0.94);
   }
-  if (shouldDownloadLibs) return createWeights(1, 0);
-  if (shouldDownloadModel) return createWeights(0, 1);
+  if (shouldDownloadLibs) return createWeights(0.96, 0);
+  if (shouldDownloadModel) return createWeights(0, 0.96);
   return createWeights(0, 0);
 };
 

--- a/src/renderer/components/ProjectCreation/LocalConfigViews/DownloadingModelView.tsx
+++ b/src/renderer/components/ProjectCreation/LocalConfigViews/DownloadingModelView.tsx
@@ -64,7 +64,7 @@ const DownloadingModelView = ({ onClickBack, onClickContinue }: Props) => {
             >
               {(progress * 100).toFixed(0)}% Complete
             </Typography>
-            {timeRemaining !== null && (
+            {timeRemaining !== null && !isDownloadComplete && (
               <Typography
                 variant="p-400"
                 sx={{ marginTop: '4px', fontSize: '12px' }}

--- a/src/renderer/components/ProjectCreation/LocalConfigViews/DownloadingModelView.tsx
+++ b/src/renderer/components/ProjectCreation/LocalConfigViews/DownloadingModelView.tsx
@@ -2,6 +2,9 @@ import Typography from '@mui/material/Typography';
 import ProgressBar from 'renderer/components/ProgressBar';
 import { useKeypress } from 'renderer/utils/hooks';
 import colors from 'renderer/colors';
+import { ApplicationStore } from 'renderer/store/sharedHelpers';
+import { useSelector } from 'react-redux';
+import { useMemo } from 'react';
 import { PrimaryButton, SecondaryButton } from '../../Blocks/Buttons';
 import { CustomColumnStack, CustomRowStack } from '../../CustomStacks';
 import LocalConfigBlock from './LocalConfigBlock';
@@ -9,18 +12,16 @@ import LocalConfigBlock from './LocalConfigBlock';
 interface Props {
   onClickBack: () => void;
   onClickContinue: () => void;
-  isDownloading: boolean;
-  progress: number;
-  isDownloadComplete: boolean;
 }
 
-const DownloadingModelView = ({
-  onClickBack,
-  onClickContinue,
-  isDownloading,
-  progress,
-  isDownloadComplete,
-}: Props) => {
+const DownloadingModelView = ({ onClickBack, onClickContinue }: Props) => {
+  const {
+    isDownloading,
+    downloadProgress: progress,
+    isDownloadComplete,
+    timeRemaining,
+  } = useSelector((store: ApplicationStore) => store.downloadModel);
+
   const continueButton = (
     <PrimaryButton
       onClick={onClickContinue}
@@ -39,6 +40,12 @@ const DownloadingModelView = ({
 
   useKeypress(onClickContinue, true, ['Enter', 'NumpadEnter']);
 
+  const timeRemainingFormatted = useMemo(() => {
+    if (timeRemaining === null) return null;
+    if (timeRemaining > 60) return `${Math.round(timeRemaining / 60)} minutes`;
+    return `${Math.round(timeRemaining)} seconds`;
+  }, [timeRemaining]);
+
   return (
     <>
       <LocalConfigBlock subtitle="Please wait while we download the local transcription tool">
@@ -50,12 +57,22 @@ const DownloadingModelView = ({
             {isDownloadComplete ? 'Download complete' : 'Downloading'}
           </Typography>
           <ProgressBar variant="determinate" value={progress * 100} />
-          <Typography
-            variant="p-400"
-            sx={{ marginTop: '4px', fontSize: '12px' }}
-          >
-            {(progress * 100).toFixed(0)}% Complete
-          </Typography>
+          <CustomRowStack justifyContent="space-between">
+            <Typography
+              variant="p-400"
+              sx={{ marginTop: '4px', fontSize: '12px' }}
+            >
+              {(progress * 100).toFixed(0)}% Complete
+            </Typography>
+            {timeRemaining !== null && (
+              <Typography
+                variant="p-400"
+                sx={{ marginTop: '4px', fontSize: '12px' }}
+              >
+                Estimated {timeRemainingFormatted} remaining
+              </Typography>
+            )}
+          </CustomRowStack>
         </CustomColumnStack>
       </LocalConfigBlock>
       <CustomRowStack

--- a/src/renderer/components/ProjectCreation/LocalConfigViews/LocalConfigView.tsx
+++ b/src/renderer/components/ProjectCreation/LocalConfigViews/LocalConfigView.tsx
@@ -34,7 +34,7 @@ const LocalConfigView = ({
   projectName,
 }: Props) => {
   const [currentConfigView, setCurrentConfigView] = useState(configViews.info);
-  const { isDownloading, downloadProgress, isDownloadComplete } = useSelector(
+  const { isDownloading } = useSelector(
     (store: ApplicationStore) => store.downloadModel
   );
 
@@ -68,9 +68,6 @@ const LocalConfigView = ({
           <DownloadingModelView
             onClickBack={() => setCurrentConfigView(configViews.info)}
             onClickContinue={() => nextView?.()}
-            isDownloading={isDownloading}
-            progress={downloadProgress}
-            isDownloadComplete={isDownloadComplete}
           />
         );
       default:

--- a/src/renderer/store/downloadModel/__tests__/reducer.test.tsx
+++ b/src/renderer/store/downloadModel/__tests__/reducer.test.tsx
@@ -5,13 +5,9 @@ import {
   FINISH_DOWNLOAD,
 } from '../actions';
 import { initialStore } from '../../sharedHelpers';
-// import { calculateTimeRemaining } from '../helpers';
+import * as helpers from '../helpers';
 
-jest.mock('../helpers', () => {
-  return {
-    calculateTimeRemaining: jest.fn().mockImplementation(() => 100),
-  };
-});
+jest.spyOn(helpers, 'calculateTimeRemaining').mockImplementation(() => 100);
 
 const RealDate = Date;
 const mockDate = new Date(12345678);
@@ -24,7 +20,7 @@ describe('Download model reducer', () => {
     expect(
       downloadModelReducer(initialStore.downloadModel, {
         type: START_DOWNLOAD,
-        payload: null,
+        payload: helpers.createDownloadStateUpdatePayload(0),
       })
     ).toEqual({
       ...initialStore.downloadModel,
@@ -51,7 +47,7 @@ describe('Download model reducer', () => {
         },
         {
           type: DOWNLOAD_PROGRESS_UPDATE,
-          payload: 0.5,
+          payload: helpers.createDownloadStateUpdatePayload(0.5),
         }
       )
     ).toEqual({
@@ -79,7 +75,7 @@ describe('Download model reducer', () => {
         },
         {
           type: FINISH_DOWNLOAD,
-          payload: null,
+          payload: helpers.createDownloadStateUpdatePayload(1),
         }
       )
     ).toEqual({

--- a/src/renderer/store/downloadModel/__tests__/reducer.test.tsx
+++ b/src/renderer/store/downloadModel/__tests__/reducer.test.tsx
@@ -5,6 +5,19 @@ import {
   FINISH_DOWNLOAD,
 } from '../actions';
 import { initialStore } from '../../sharedHelpers';
+// import { calculateTimeRemaining } from '../helpers';
+
+jest.mock('../helpers', () => {
+  return {
+    calculateTimeRemaining: jest.fn().mockImplementation(() => 100),
+  };
+});
+
+const RealDate = Date;
+const mockDate = new Date(12345678);
+jest
+  .spyOn(global, 'Date')
+  .mockImplementation(() => mockDate as unknown as string);
 
 describe('Download model reducer', () => {
   it('should handle download start', () => {
@@ -18,6 +31,9 @@ describe('Download model reducer', () => {
       isDownloading: true,
       downloadProgress: 0,
       isDownloadComplete: false,
+      lastUpdated: mockDate,
+      previousDownloadProgress: 0,
+      timeRemaining: null,
     });
   });
 
@@ -27,8 +43,11 @@ describe('Download model reducer', () => {
         {
           ...initialStore.downloadModel,
           isDownloading: true,
-          downloadProgress: 0,
+          downloadProgress: 0.2,
           isDownloadComplete: false,
+          lastUpdated: new RealDate(mockDate.getTime() - 2000),
+          previousDownloadProgress: 0,
+          timeRemaining: null,
         },
         {
           type: DOWNLOAD_PROGRESS_UPDATE,
@@ -40,6 +59,9 @@ describe('Download model reducer', () => {
       isDownloading: true,
       downloadProgress: 0.5,
       isDownloadComplete: false,
+      lastUpdated: mockDate,
+      previousDownloadProgress: 0.2,
+      timeRemaining: 100,
     });
   });
 
@@ -51,6 +73,9 @@ describe('Download model reducer', () => {
           isDownloading: true,
           downloadProgress: 0.5,
           isDownloadComplete: false,
+          lastUpdated: new RealDate(),
+          previousDownloadProgress: 0.2,
+          timeRemaining: null,
         },
         {
           type: FINISH_DOWNLOAD,
@@ -62,6 +87,9 @@ describe('Download model reducer', () => {
       isDownloading: false,
       downloadProgress: 1,
       isDownloadComplete: true,
+      lastUpdated: mockDate,
+      previousDownloadProgress: 0.5,
+      timeRemaining: 0,
     });
   });
 });

--- a/src/renderer/store/downloadModel/actions.ts
+++ b/src/renderer/store/downloadModel/actions.ts
@@ -1,22 +1,26 @@
 import { Action } from '../action';
+import {
+  createDownloadStateUpdatePayload,
+  DownloadStateUpdatePayload,
+} from './helpers';
 
 export const START_DOWNLOAD = 'START_DOWNLOAD';
 export const DOWNLOAD_PROGRESS_UPDATE = 'DOWNLOAD_PROGRESS_UPDATE';
 export const FINISH_DOWNLOAD = 'FINISH_DOWNLOAD';
 
-export const startDownload: () => Action<null> = () => ({
+export const startDownload: () => Action<DownloadStateUpdatePayload> = () => ({
   type: START_DOWNLOAD,
-  payload: null,
+  payload: createDownloadStateUpdatePayload(0),
 });
 
-export const updateDownloadProgress: (progress: number) => Action<number> = (
-  progress
-) => ({
+export const updateDownloadProgress: (
+  progress: number
+) => Action<DownloadStateUpdatePayload> = (progress) => ({
   type: DOWNLOAD_PROGRESS_UPDATE,
-  payload: progress,
+  payload: createDownloadStateUpdatePayload(progress),
 });
 
-export const finishDownload: () => Action<null> = () => ({
+export const finishDownload: () => Action<DownloadStateUpdatePayload> = () => ({
   type: FINISH_DOWNLOAD,
-  payload: null,
+  payload: createDownloadStateUpdatePayload(1),
 });

--- a/src/renderer/store/downloadModel/helpers.ts
+++ b/src/renderer/store/downloadModel/helpers.ts
@@ -5,5 +5,32 @@
 export interface DownloadModel {
   isDownloading: boolean;
   isDownloadComplete: boolean;
-  downloadProgress: number; // Used for showing current download progress
+  // The progress of the download, a value between 0 and 1
+  downloadProgress: number;
+  // The date at which the time remaining was last updated
+  lastUpdated: Date | null;
+  // The amount of time remaining on the download, in seconds
+  timeRemaining: number | null;
+  // The progress of the download on the previous update, a value between 0 and 1
+  previousDownloadProgress: number;
 }
+
+type CalculateTimeRemaining = (
+  newLastUpdated: Date,
+  oldLastUpdated: Date,
+  newDownloadProgress: number,
+  oldDownloadProgress: number
+) => number;
+
+export const calculateTimeRemaining: CalculateTimeRemaining = (
+  newLastUpdated,
+  oldLastUpdated,
+  newDownloadProgress,
+  oldDownloadProgress
+) => {
+  const timeDifference =
+    (newLastUpdated.getTime() - oldLastUpdated.getTime()) / 1000;
+  const progressPerTime =
+    (newDownloadProgress - oldDownloadProgress) / timeDifference;
+  return (1 - newDownloadProgress) / progressPerTime;
+};

--- a/src/renderer/store/downloadModel/helpers.ts
+++ b/src/renderer/store/downloadModel/helpers.ts
@@ -34,3 +34,18 @@ export const calculateTimeRemaining: CalculateTimeRemaining = (
     (newDownloadProgress - oldDownloadProgress) / timeDifference;
   return (1 - newDownloadProgress) / progressPerTime;
 };
+
+export type DownloadStateUpdatePayload = {
+  lastUpdated: Date;
+  downloadProgress: number;
+};
+
+type CreateDownloadStateUpdatePayload = (
+  progress: number
+) => DownloadStateUpdatePayload;
+
+export const createDownloadStateUpdatePayload: CreateDownloadStateUpdatePayload =
+  (progress) => ({
+    lastUpdated: new Date(),
+    downloadProgress: progress,
+  });

--- a/src/renderer/store/downloadModel/reducer.ts
+++ b/src/renderer/store/downloadModel/reducer.ts
@@ -5,7 +5,11 @@ import {
   FINISH_DOWNLOAD,
 } from './actions';
 import { ApplicationStore, initialStore } from '../sharedHelpers';
-import { calculateTimeRemaining, DownloadModel } from './helpers';
+import {
+  calculateTimeRemaining,
+  DownloadModel,
+  DownloadStateUpdatePayload,
+} from './helpers';
 import { Action } from '../action';
 
 // The time between updates to the download time remaining, in milliseconds
@@ -13,7 +17,7 @@ const timeRemainingUpdateInterval = 1000;
 
 const downloadModelReducer: Reducer<
   ApplicationStore['downloadModel'],
-  Action<any>
+  Action<DownloadStateUpdatePayload>
 > = (downloadModel = initialStore.downloadModel, action) => {
   if (action.type === START_DOWNLOAD) {
     return {
@@ -21,17 +25,18 @@ const downloadModelReducer: Reducer<
       isDownloading: true,
       isDownloadComplete: false,
       downloadProgress: 0,
-      lastUpdated: new Date(),
+      lastUpdated: action.payload.lastUpdated,
       previousDownloadProgress: 0,
       timeRemaining: null,
     } as DownloadModel;
   }
 
   if (action.type === DOWNLOAD_PROGRESS_UPDATE) {
-    const newLastUpdated = new Date();
+    const newLastUpdated = action.payload.lastUpdated;
     const oldLastUpdated = downloadModel.lastUpdated as Date;
-    const newDownloadProgress = action.payload;
+    const newDownloadProgress = action.payload.downloadProgress;
     const oldDownloadProgress = downloadModel.previousDownloadProgress;
+
     // Only update time remaining every t seconds
     if (
       newLastUpdated.getTime() - oldLastUpdated.getTime() >
@@ -39,8 +44,8 @@ const downloadModelReducer: Reducer<
     ) {
       return {
         ...downloadModel,
-        downloadProgress: action.payload,
-        lastUpdated: new Date(),
+        downloadProgress: newDownloadProgress,
+        lastUpdated: newLastUpdated,
         previousDownloadProgress: downloadModel.downloadProgress,
         timeRemaining: calculateTimeRemaining(
           newLastUpdated,
@@ -52,7 +57,7 @@ const downloadModelReducer: Reducer<
     }
     return {
       ...downloadModel,
-      downloadProgress: action.payload,
+      downloadProgress: newDownloadProgress,
     } as DownloadModel;
   }
 
@@ -62,7 +67,7 @@ const downloadModelReducer: Reducer<
       isDownloading: false,
       isDownloadComplete: true,
       downloadProgress: 1,
-      lastUpdated: new Date(),
+      lastUpdated: action.payload.lastUpdated,
       previousDownloadProgress: downloadModel.downloadProgress,
       timeRemaining: 0,
     } as DownloadModel;

--- a/src/renderer/store/sharedHelpers.ts
+++ b/src/renderer/store/sharedHelpers.ts
@@ -73,6 +73,9 @@ export const initialStore: ApplicationStore = {
     isDownloading: false,
     isDownloadComplete: false,
     downloadProgress: 0,
+    lastUpdated: null,
+    timeRemaining: null,
+    previousDownloadProgress: 0,
   },
   playback: {
     rangeOverride: null,


### PR DESCRIPTION
## Summary

Adds the time remaining (in minutes or seconds) to the download model UI

<hr/>

### Why is this change needed?

In the designs but not included in original local transcription UI PR.

<hr/>

### What did you change?

Added some extra states to the download model redux so that time remaining can be calculated based off of how much progress has been achieved in a certain time interval.

<hr/>

### Does it depend on any other changes/PRs?

<hr/>

### Screenshots of UI changes, if any

![image](https://user-images.githubusercontent.com/69132311/193988554-1884e119-af3b-4b54-a33d-d0e46901adf0.png)

![image](https://user-images.githubusercontent.com/69132311/193988834-e53dd53d-2b82-450b-b615-9ef4f61bcdff.png)

<hr/>

### Future work

Currently, the time remaining jumps around a fair bit. This can most easily be seen in the number of seconds remaining. We can store lots of time remaining values and then take the average but that's a fair bit of computation for something that happens every couple of milliseconds.

<hr/>

### Testing details if applicable

Download the model again. Sorry. Means deleting the `localTranscriptionAssets` folder from your app data path.
On windows that is `C:\Users\<insert-user-here>\AppData\Roaming\Electron\mlvet\localTranscriptionAssets`

<hr/>

### OS

<!-- To select your OS. Place an 'x' within [ ]. eg. - [x] Linux -->

- [ ] Linux
- [x] MacOS
- [x] Windows
