### PR TITLE
Feature/take words editing

### DIFF
--- a/src/main/takeDetection/constants.ts
+++ b/src/main/takeDetection/constants.ts
@@ -1,2 +1,2 @@
 // eslint-disable-next-line import/prefer-default-export
-export const THRESHOLD = 1;
+export const THRESHOLD = 0.3;

--- a/src/renderer/components/Editor/TakeComponent.tsx
+++ b/src/renderer/components/Editor/TakeComponent.tsx
@@ -144,6 +144,10 @@ const TakeComponent = ({
 
   const TakeWords = takeWords.map((word, index, words) => {
     const wordIndex = transcriptionIndex + index;
+
+    // Using wordIndex will not work with takes as 'words' will not
+    // equal the entire transcription words, only the take words
+
     return (
       <WordOuterComponent
         key={`word-outer-${word.originalIndex}-${word.pasteKey}`}

--- a/src/renderer/components/Editor/WordOuterComponent.tsx
+++ b/src/renderer/components/Editor/WordOuterComponent.tsx
@@ -110,7 +110,7 @@ const WordOuterComponent = ({
     <WordAndSpaceContainer
       key={`container-${word.originalIndex}-${word.pasteKey}`}
     >
-      {word.deleted ? (
+      {word.deleted && word.takeInfo === null && (
         <EditMarker
           key={`edit-marker-${word.originalIndex}-${word.pasteKey}`}
           word={word}
@@ -122,7 +122,8 @@ const WordOuterComponent = ({
           popoverWidth={popoverWidth}
           transcriptionBlockRef={transcriptionBlockRef}
         />
-      ) : (
+      )}
+      {!word.deleted && (
         <Fragment key={`${word.originalIndex}-${word.pasteKey}`}>
           <WordSpace
             key={`space-${word.originalIndex}-${word.pasteKey}`}

--- a/src/renderer/store/transcriptionWords/helpers/takeUtils.ts
+++ b/src/renderer/store/transcriptionWords/helpers/takeUtils.ts
@@ -1,0 +1,9 @@
+import { TakeInfo, Word } from '../../../../sharedTypes';
+
+type GetNewTakeInfo = (tf: TakeInfo | null, word: Word) => TakeInfo | null;
+
+// eslint-disable-next-line import/prefer-default-export
+export const getNewTakeInfo: GetNewTakeInfo = (tf, word) => {
+  if (word.takeInfo !== null) return word.takeInfo;
+  return tf;
+};

--- a/src/renderer/store/transcriptionWords/helpers/takeUtils.ts
+++ b/src/renderer/store/transcriptionWords/helpers/takeUtils.ts
@@ -2,8 +2,11 @@ import { TakeInfo, Word } from '../../../../sharedTypes';
 
 type GetNewTakeInfo = (tf: TakeInfo | null, word: Word) => TakeInfo | null;
 
+/*
+ * Returns the first takeInfo that is not null, from the list of words
+ */
 // eslint-disable-next-line import/prefer-default-export
-export const getNewTakeInfo: GetNewTakeInfo = (tf, word) => {
+export const getWordsTakeInfo: GetNewTakeInfo = (tf, word) => {
   if (word.takeInfo !== null) return word.takeInfo;
   return tf;
 };

--- a/src/renderer/store/transcriptionWords/reducer.ts
+++ b/src/renderer/store/transcriptionWords/reducer.ts
@@ -82,12 +82,10 @@ const transcriptionWordsReducer: Reducer<Word[], Action<any>> = (
 
     // Replace takeInfo of pasted words with takeInfo of words from paste section
     const takeInfo = wordsToReplace.reduce(getNewTakeInfo, null);
-    if (takeInfo !== null) {
-      wordsToPaste = wordsToPaste.map((word) => ({
-        ...word,
-        takeInfo,
-      }));
-    }
+    wordsToPaste = wordsToPaste.map((word) => ({
+      ...word,
+      takeInfo,
+    }));
 
     return [...prefix, ...replacedWords, ...wordsToPaste, ...suffix];
   }

--- a/src/renderer/store/transcriptionWords/reducer.ts
+++ b/src/renderer/store/transcriptionWords/reducer.ts
@@ -33,7 +33,7 @@ import {
   UndoPasteWordsPayload,
   UndoRestoreSectionPayload,
 } from './opPayloads';
-import { getNewTakeInfo } from './helpers/takeUtils';
+import { getWordsTakeInfo } from './helpers/takeUtils';
 
 /**
  *  Nested reducer for handling transcription words
@@ -81,7 +81,7 @@ const transcriptionWordsReducer: Reducer<Word[], Action<any>> = (
     const suffix = words.slice(endIndex);
 
     // Replace takeInfo of pasted words with takeInfo of words from paste section
-    const takeInfo = wordsToReplace.reduce(getNewTakeInfo, null);
+    const takeInfo = wordsToReplace.reduce(getWordsTakeInfo, null);
     wordsToPaste = wordsToPaste.map((word) => ({
       ...word,
       takeInfo,

--- a/src/renderer/store/transcriptionWords/reducer.ts
+++ b/src/renderer/store/transcriptionWords/reducer.ts
@@ -33,6 +33,7 @@ import {
   UndoPasteWordsPayload,
   UndoRestoreSectionPayload,
 } from './opPayloads';
+import { getNewTakeInfo } from './helpers/takeUtils';
 
 /**
  *  Nested reducer for handling transcription words
@@ -72,12 +73,21 @@ const transcriptionWordsReducer: Reducer<Word[], Action<any>> = (
       0,
       ...words.map((word) => word.pasteKey)
     );
-    const wordsToPaste = clipboard.map((word, index) => ({
+    let wordsToPaste = clipboard.map((word, index) => ({
       ...word,
       pasteKey: highestExistingPasteKey + index + 1,
     }));
 
     const suffix = words.slice(endIndex);
+
+    // Replace takeInfo of pasted words with takeInfo of words from paste section
+    const takeInfo = wordsToReplace.reduce(getNewTakeInfo, null);
+    if (takeInfo !== null) {
+      wordsToPaste = wordsToPaste.map((word) => ({
+        ...word,
+        takeInfo,
+      }));
+    }
 
     return [...prefix, ...replacedWords, ...wordsToPaste, ...suffix];
   }


### PR DESCRIPTION
## Summary

Adds functionality for the following:
- Deleting words from takes
- Move words between takes
- Move words out of takes (into main transcription)
- Move words into takes (from main transcription)

Does not include functionality for:
- Deleting a take (by deleting all words inside a take)

**Note:**
When words are moved out of a take or deleted from a take (`word.deleted === true`), the edit marker is not shown. The edit marker functionality was built around transcription indexes, not take indexes and this complicates things. It could be added later but I do not think its a valuable use of resources at this time.

<hr/>

### What did you change?

- Added take detection back by reducing the take detection similarity threshold to 0.3
- Hid edit marker in words that are part of takes
- Added functionality to `transcriptionWords` reducer to update pasted words with take info of words in paste section

<hr/>

### Testing details if applicable

Please try and break it. [Max's video](https://drive.google.com/file/d/1uPAz1wQuHmjoE1BbSUpxydbzrqJKGkpC/view?usp=sharing) with takes is in the google drive.

<hr/>

### OS

<!-- To select your OS. Place an 'x' within [ ]. eg. - [x] Linux -->

- [ ] Linux
- [x] MacOS
- [x] Windows
