### PR TITLE
Chore/portrait video handling

### DIFF
--- a/src/renderer/components/Editor/ResizeManager.tsx
+++ b/src/renderer/components/Editor/ResizeManager.tsx
@@ -18,7 +18,7 @@ import { getAspectRatio, getElementSize } from 'renderer/utils/ui';
 const pageLayoutPadding = { x: 96 * 2 + 2, y: 64 };
 
 const pageLayoutOptions = {
-  minTranscriptionWidth: 120,
+  minTranscriptionWidth: 240,
   minVideoPreviewWidth: 120,
 };
 

--- a/src/renderer/components/RecentProjectsBlock.tsx
+++ b/src/renderer/components/RecentProjectsBlock.tsx
@@ -187,13 +187,23 @@ const RecentProjectsBlock = () => {
           <RecentProjectsItem key={id} onClick={() => handleOpenProject(id)}>
             <Grid container spacing={2}>
               <RecentProjectsSubItem item xs={8}>
-                <img
-                  src={`data:image/png;base64,${thumbnails[id] ?? ''}`}
-                  alt={`Thumbnail for project ${name}`}
-                  style={{
-                    maxWidth: 180,
+                <Stack
+                  sx={{
+                    width: 180,
+                    justifyContent: 'center',
+                    flexDirection: 'row',
+                    backgroundColor: colors.grey[900],
                   }}
-                />
+                >
+                  <img
+                    src={`data:image/png;base64,${thumbnails[id] ?? ''}`}
+                    alt={`Thumbnail for project ${name}`}
+                    style={{
+                      maxWidth: 180,
+                      maxHeight: 100,
+                    }}
+                  />
+                </Stack>
                 <Typography
                   variant="h1"
                   style={{ fontWeight: 'bold', marginLeft: 40 }}

--- a/src/renderer/components/Scrubber.tsx
+++ b/src/renderer/components/Scrubber.tsx
@@ -109,7 +109,7 @@ const Scrubber = ({
   };
 
   return (
-    <div>
+    <div id="scrubber">
       <Slider
         defaultValue={0}
         value={sliderValue}

--- a/src/renderer/components/VideoPreview/videoPreview.css
+++ b/src/renderer/components/VideoPreview/videoPreview.css
@@ -4,4 +4,13 @@
 
 video {
   width: 100%;
+  height: 100%;
+}
+
+.replay-ui-container {
+  height: 100%;
+}
+
+.replay {
+  height: 100%;
 }

--- a/src/renderer/pages/Project.tsx
+++ b/src/renderer/pages/Project.tsx
@@ -175,10 +175,16 @@ const ProjectPage = () => {
                     options={videoResizeOptions}
                     sx={{ flex: '0 0 auto' }}
                   />
-                  <Stack justifyContent="center" sx={{ width: 'fit-content' }}>
+                  <Stack
+                    id="video-preview"
+                    justifyContent="center"
+                    sx={{ width: 'fit-content', height: '100%' }}
+                  >
                     <Box
+                      id="video-preview-container"
                       sx={{
                         width: `${videoPreviewContainerWidth}px`,
+                        maxHeight: 'calc(100% - 48px)',
                       }}
                       ref={videoPreviewContainerRef}
                     >


### PR DESCRIPTION
## Summary

Styling additions so that video preview and recent projects can handle portrait videos.

<hr/>

### What did you change?

- Styling for video preview (and resize) to handle vertical videos
- Styling for recent projects thumbnail to handle vertical videos
- A fix for a minor bug with video preview resize where it extends slightly past the end of the page on resize

<hr/>

### Screenshots of UI changes, if any

![image](https://user-images.githubusercontent.com/69132311/194787447-cc24ed62-c5eb-445b-8983-1f3946b1556d.png)

![image](https://user-images.githubusercontent.com/69132311/194787454-15ca3b11-3b3d-47f4-9330-169a3d0147a2.png)

![image](https://user-images.githubusercontent.com/69132311/194787467-58fd8b87-b444-484a-afa3-1bdd91b94ae9.png)


<hr/>

### Explain things which the reviewers are likely to need explaining. Remember that they didn’t write the code.

Who's that hot bod in the screenshots?

<hr/>

### OS

<!-- To select your OS. Place an 'x' within [ ]. eg. - [x] Linux -->

- [ ] Linux
- [ ] MacOS
- [x] Windows
