### PR TITLE
Update bug reporter url

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,6 @@
 export const CURRENT_SCHEMA_VERSION = 2;
 export const URL_USER_FEEDBACK_FORM = 'https://forms.gle/YNozsPZxF4kxSuud8';
 export const BUG_REPORT_API_URL =
-  'https://mlvet-bug-reporter-mlvet-bug-reporter-9xw6.vercel.app/api/reportBug';
+  'https://mlvet-bug-reporter-j4v5.vercel.app/api/reportBug';
 export const URL_ASSEMBLYAI_SIGNUP =
   'https://app.assemblyai.com/signup?_ga=2.64947567.1548607132.1661819143-2080070454.1661819143';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,6 @@
 export const CURRENT_SCHEMA_VERSION = 2;
 export const URL_USER_FEEDBACK_FORM = 'https://forms.gle/YNozsPZxF4kxSuud8';
 export const BUG_REPORT_API_URL =
-  'https://mlvet-bug-reporter-j4v5-r8g80jccu-mlvet.vercel.app/api/reportBug';
+  'https://mlvet-bug-reporter-j4v5.vercel.app/api/reportBug';
 export const URL_ASSEMBLYAI_SIGNUP =
   'https://app.assemblyai.com/signup?_ga=2.64947567.1548607132.1661819143-2080070454.1661819143';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,6 @@
 export const CURRENT_SCHEMA_VERSION = 2;
 export const URL_USER_FEEDBACK_FORM = 'https://forms.gle/YNozsPZxF4kxSuud8';
 export const BUG_REPORT_API_URL =
-  'https://mlvet-bug-reporter-j4v5.vercel.app/api/reportBug';
+  'https://mlvet-bug-reporter-j4v5-r8g80jccu-mlvet.vercel.app/api/reportBug';
 export const URL_ASSEMBLYAI_SIGNUP =
   'https://app.assemblyai.com/signup?_ga=2.64947567.1548607132.1661819143-2080070454.1661819143';


### PR DESCRIPTION
## Summary

Changes the url for the bug-reporter api.
3 commits, one line changed. Some sort of record(?).

<hr/>

### Why is this change needed?

Because the bug-reporter server code was moved to the organisation repository, so the server needed to be redeployed under a new domain. 

<hr/>

### Does it depend on any other changes/PRs?

IMPORTANT PLS READ!
This depends on the mlvet repo being moved to the organisation account. The bug-report feature will not work until that happens, and will instead tell you to "try again later". This is because the server code already points to the to-be location of the mlvet repo, not the current location.

### OS

- [ ] Linux
- [ ] MacOS
- [x] Windows
