### PR TITLE
Feature/undo take select

### DIFF
--- a/src/renderer/components/Editor/TakeComponent.tsx
+++ b/src/renderer/components/Editor/TakeComponent.tsx
@@ -1,12 +1,6 @@
 import styled from '@emotion/styled';
 import { Avatar, Box } from '@mui/material';
-import {
-  IndexRange,
-  TakeGroup,
-  TakeInfo,
-  Transcription,
-  Word,
-} from 'sharedTypes';
+import { IndexRange, Transcription, Word } from 'sharedTypes';
 import React, {
   RefObject,
   useCallback,

--- a/src/renderer/components/Editor/TakeComponent.tsx
+++ b/src/renderer/components/Editor/TakeComponent.tsx
@@ -104,6 +104,8 @@ const TakeComponent = ({
     const takeGroup = transcription.takeGroups.find(
       (tg) => tg.id === takeInfo.takeGroupId
     ) as TakeGroup;
+
+    // only makes action if the selection has changed
     if (
       takeGroup.activeTakeIndex !== takeInfo.takeIndex ||
       !takeGroup.takeSelected

--- a/src/renderer/components/Editor/TakeComponent.tsx
+++ b/src/renderer/components/Editor/TakeComponent.tsx
@@ -100,10 +100,18 @@ const TakeComponent = ({
   const takeRef = useRef<HTMLDivElement>(null);
 
   const onSelectTake = useCallback(() => {
-    const takeInfo = takeWords[0].takeInfo as TakeInfo;
+    const { takeInfo } = takeWords[0];
+    if (!takeInfo) {
+      return;
+    }
+
     const takeGroup = transcription.takeGroups.find(
       (tg) => tg.id === takeInfo.takeGroupId
-    ) as TakeGroup;
+    );
+
+    if (!takeGroup) {
+      return;
+    }
 
     // only makes action if the selection has changed
     if (

--- a/src/renderer/components/Editor/TakeGroupComponent.tsx
+++ b/src/renderer/components/Editor/TakeGroupComponent.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import BlockIcon from '@mui/icons-material/Block';
 import { Box, ClickAwayListener, Stack } from '@mui/material';
 import { ClientId } from 'collabTypes/collabShadowTypes';
-import React, { RefObject, useMemo, useState } from 'react';
+import React, { RefObject, useEffect, useMemo, useState } from 'react';
 import colors from 'renderer/colors';
 import { EditWordState } from 'renderer/store/sharedHelpers';
 import { IndexRange, TakeGroup, Transcription, Word } from 'sharedTypes';
@@ -214,6 +214,14 @@ const TakeGroupComponent = ({
       />
     );
   });
+
+  useEffect(() => {
+    // when undoing the first take selection, it reverts back to the initial state
+    setIsFirstTimeOpen(!takeGroup.takeSelected);
+    if (!takeGroup.takeSelected) {
+      setIsTakeGroupOpened(true);
+    }
+  }, [takeGroup.takeSelected]);
 
   return (
     <ClickAwayListener onClickAway={clickAway}>

--- a/src/renderer/store/currentProject/reducer.ts
+++ b/src/renderer/store/currentProject/reducer.ts
@@ -33,6 +33,7 @@ import {
   DELETE_TAKE_GROUP,
   SELECT_TAKE,
   UNDO_DELETE_TAKE_GROUP,
+  UNDO_SELECT_TAKE,
 } from '../takeGroups/actions';
 
 const currentProjectReducer: Reducer<
@@ -107,6 +108,7 @@ const currentProjectReducer: Reducer<
       SPLIT_WORD,
       UNDO_SPLIT_WORD,
       SELECT_TAKE,
+      UNDO_SELECT_TAKE,
       DELETE_TAKE_GROUP,
       UNDO_DELETE_TAKE_GROUP,
       RESTORE_SECTION,

--- a/src/renderer/store/takeGroups/actions.ts
+++ b/src/renderer/store/takeGroups/actions.ts
@@ -2,19 +2,28 @@ import { IndexRange, TakeGroup, TakeInfo } from '../../../sharedTypes';
 import { Action } from '../action';
 import {
   DeleteTakeGroupPayload,
-  SelectTakeGroupPayload,
+  SelectTakePayload,
   UndoDeleteTakeGroupPayload,
+  UndoSelectTakePayload,
 } from './opPayloads';
 
 export const SELECT_TAKE = 'SELECT_TAKE';
+export const UNDO_SELECT_TAKE = 'UNDO_SELECT_TAKE';
 export const DELETE_TAKE_GROUP = 'DELETE_TAKE_GROUP';
 export const UNDO_DELETE_TAKE_GROUP = 'UNDO_DELETE_TAKE_GROUP';
 
-export const selectTake: (
-  takeInfo: TakeInfo
-) => Action<SelectTakeGroupPayload> = (takeInfo) => ({
+export const selectTake: (takeInfo: TakeInfo) => Action<SelectTakePayload> = (
+  takeInfo
+) => ({
   type: SELECT_TAKE,
   payload: takeInfo,
+});
+
+export const undoSelectTake: (
+  takeGroup: TakeGroup
+) => Action<UndoSelectTakePayload> = (takeGroup) => ({
+  type: UNDO_SELECT_TAKE,
+  payload: { takeGroup },
 });
 
 export const deleteTakeGroup: (

--- a/src/renderer/store/takeGroups/opPayloads.ts
+++ b/src/renderer/store/takeGroups/opPayloads.ts
@@ -1,6 +1,10 @@
 import { IndexRange, TakeGroup, TakeInfo } from '../../../sharedTypes';
 
-export type SelectTakeGroupPayload = TakeInfo;
+export type SelectTakePayload = TakeInfo;
+
+export interface UndoSelectTakePayload {
+  takeGroup: TakeGroup;
+}
 
 export type DeleteTakeGroupPayload = number;
 

--- a/src/renderer/store/takeGroups/ops/selectTake.ts
+++ b/src/renderer/store/takeGroups/ops/selectTake.ts
@@ -1,0 +1,14 @@
+import { Op } from 'renderer/store/undoStack/helpers';
+import { TakeGroup, TakeInfo } from 'sharedTypes';
+import { SelectTakePayload, UndoSelectTakePayload } from '../opPayloads';
+import { selectTake, undoSelectTake } from '../actions';
+
+export type SelectTakeOp = Op<SelectTakePayload, UndoSelectTakePayload>;
+
+export const makeSelectTake: (
+  takeInfo: TakeInfo,
+  takeGroup: TakeGroup
+) => SelectTakeOp = (takeInfo, takeGroup) => ({
+  do: [selectTake(takeInfo)],
+  undo: [undoSelectTake(takeGroup)],
+});

--- a/src/renderer/store/takeGroups/reducer.ts
+++ b/src/renderer/store/takeGroups/reducer.ts
@@ -5,8 +5,12 @@ import {
   DELETE_TAKE_GROUP,
   SELECT_TAKE,
   UNDO_DELETE_TAKE_GROUP,
+  UNDO_SELECT_TAKE,
 } from './actions';
-import { UndoDeleteTakeGroupPayload } from './opPayloads';
+import {
+  UndoDeleteTakeGroupPayload,
+  UndoSelectTakePayload,
+} from './opPayloads';
 
 /**
  * Stores the take groups for the current transcription
@@ -23,6 +27,12 @@ const takeGroupsReducer: Reducer<TakeGroup[], Action<any>> = (
         ? { ...takeGroup, activeTakeIndex: takeIndex, takeSelected: true }
         : takeGroup
     );
+  }
+
+  if (action.type === UNDO_SELECT_TAKE) {
+    const { takeGroup } = action.payload as UndoSelectTakePayload;
+
+    return takeGroups.map((tg) => (tg.id === takeGroup.id ? takeGroup : tg));
   }
 
   if (action.type === DELETE_TAKE_GROUP) {

--- a/src/renderer/store/transcription/reducer.ts
+++ b/src/renderer/store/transcription/reducer.ts
@@ -22,6 +22,7 @@ import {
   DELETE_TAKE_GROUP,
   SELECT_TAKE,
   UNDO_DELETE_TAKE_GROUP,
+  UNDO_SELECT_TAKE,
 } from '../takeGroups/actions';
 import transcriptionTakesReducer from '../transcriptionTakes/reducer';
 import takeGroupsReducer from '../takeGroups/reducer';
@@ -70,9 +71,12 @@ const transcriptionReducer: Reducer<Transcription | null, Action<any>> = (
 
   // Delegate take-related actions to takes reducer and take groups reducer
   if (
-    [SELECT_TAKE, DELETE_TAKE_GROUP, UNDO_DELETE_TAKE_GROUP].includes(
-      action.type
-    )
+    [
+      SELECT_TAKE,
+      UNDO_SELECT_TAKE,
+      DELETE_TAKE_GROUP,
+      UNDO_DELETE_TAKE_GROUP,
+    ].includes(action.type)
   ) {
     // Update take groups first, so that updateOutputTimes uses the correct take groups
     const takeGroups = takeGroupsReducer(transcription.takeGroups, action);

--- a/src/renderer/store/undoStack/helpers.ts
+++ b/src/renderer/store/undoStack/helpers.ts
@@ -5,7 +5,9 @@ import {
 } from '../selection/actions';
 import {
   DeleteTakeGroupPayload,
+  SelectTakePayload,
   UndoDeleteTakeGroupPayload,
+  UndoSelectTakePayload,
 } from '../takeGroups/opPayloads';
 import {
   CorrectWordPayload,
@@ -59,7 +61,8 @@ export type DoPayload =
   | CorrectWordPayload
   | MergeWordsPayload
   | SplitWordPayload
-  | DeleteTakeGroupPayload;
+  | DeleteTakeGroupPayload
+  | SelectTakePayload;
 
 export type UndoPayload =
   | UndoDeleteSelectionPayload
@@ -67,7 +70,8 @@ export type UndoPayload =
   | UndoCorrectWordPayload
   | UndoMergeWordsPayload
   | UndoSplitWordPayload
-  | UndoDeleteTakeGroupPayload;
+  | UndoDeleteTakeGroupPayload
+  | UndoSelectTakePayload;
 
 export type OpPayload =
   | DoPayload


### PR DESCRIPTION
## Undo Take Select
Adds the ability to undo selecting a take.

<!-- Provide a summary of what your changes achieve aka what the goal of the PR is -->

<hr/>

### Why is this change needed?
So that the user is able to intuitively use the undo stack to revert take selection changes.

### Screenshots
<hr/>

https://user-images.githubusercontent.com/58348527/195025475-7f9df7b2-2a6b-4820-a4e9-0c2a560b7b5c.mp4

<hr/>

### OS

<!-- To select your OS. Place an 'x' within [ ]. eg. - [x] Linux -->

- [ ] Linux
- [x] MacOS
- [x] Windows
