### PR TITLE
Bugfix/play all takes

### DIFF
--- a/src/sharedUtils.ts
+++ b/src/sharedUtils.ts
@@ -132,7 +132,7 @@ export const isInInactiveTake: (
 
   const takeGroup = takeGroups.find((group) => group.id === takeGroupId);
 
-  if (takeGroup?.activeTakeIndex === takeIndex) {
+  if (takeGroup?.activeTakeIndex === takeIndex || !takeGroup?.takeSelected) {
     return false;
   }
 

--- a/src/sharedUtils.ts
+++ b/src/sharedUtils.ts
@@ -132,6 +132,8 @@ export const isInInactiveTake: (
 
   const takeGroup = takeGroups.find((group) => group.id === takeGroupId);
 
+  // a take is not considered inactive if it is the active/selected take
+  // or when no takes have been selected in the take group
   if (takeGroup?.activeTakeIndex === takeIndex || !takeGroup?.takeSelected) {
     return false;
   }

--- a/src/transcriptProcessing/__tests__/updateOutputTimes.test.tsx
+++ b/src/transcriptProcessing/__tests__/updateOutputTimes.test.tsx
@@ -69,7 +69,7 @@ describe('updateOutputTimes', () => {
     ];
 
     const takeGroups: TakeGroup[] = [
-      { activeTakeIndex: 0, id: 0, takeSelected: false },
+      { activeTakeIndex: 0, id: 0, takeSelected: true },
     ];
 
     expect(updateOutputTimes(inputWords, takeGroups)).toEqual({


### PR DESCRIPTION
<!-- Notes!
    Please do not forget to:
        1. assign some one to review your pull request!
        2. did you include unit tests?
        3. did you merge develop into your branch?
        4. notify the #pr channel on slack!

    Feel free to remove the sections which you do not fill out
 -->

## Fix Skipping Takes / Play All Takes
Note: changes may only work for new project files

<!-- Provide a summary of what your changes achieve aka what the goal of the PR is -->

<hr/>

### Why is this change needed?
Before this change, when a take group had no selected/active take (e.g. after the project is created), the playback would only play the first take in the group, skipping over the other takes. Intuitively this should not occur. 

Therefore this bugfix works with the assumption that all takes in a group should be considered part of the transcript until one is selected.

<hr/>

### What did you change?
Words from take group that has no selected take are considered active (return `false` in `isInInactiveTake`)

<hr/>

### Screenshots of UI changes, if any

<hr/>

https://user-images.githubusercontent.com/58348527/195279943-be70f15d-f79b-4b3c-8082-6fe43ff57881.mp4


<hr/>

### OS

<!-- To select your OS. Place an 'x' within [ ]. eg. - [x] Linux -->

- [ ] Linux
- [ ] MacOS
- [x] Windows
