### PR TITLE
Feature/make take content preivew easier

### DIFF
--- a/src/renderer/components/Editor/TakeGroupComponent.tsx
+++ b/src/renderer/components/Editor/TakeGroupComponent.tsx
@@ -9,6 +9,7 @@ import { EditWordState } from 'renderer/store/sharedHelpers';
 import { IndexRange, TakeGroup, Transcription, Word } from 'sharedTypes';
 import dispatchOp from 'renderer/store/dispatchOp';
 import { makeDeleteTakeGroup } from 'renderer/store/takeGroups/ops/deleteTakeGroup';
+import { isEventInElement, transcriptionContentId } from 'renderer/utils/ui';
 import TakeComponent from './TakeComponent';
 import UngroupTakesModal from './UngroupTakesModal';
 import { PartialSelectState, WordMouseHandler } from './DragSelectManager';
@@ -73,6 +74,8 @@ const TakeGroupComponent = ({
   transcription,
   ...passThroughProps
 }: TakeGroupComponentProps) => {
+  const takeGroupId = `take-group-${takeGroup.id}`;
+
   const [isTakeGroupOpened, setIsTakeGroupOpened] = useState(
     !takeGroup.takeSelected
   );
@@ -150,8 +153,14 @@ const TakeGroupComponent = ({
     handleModalClose();
   };
 
-  const clickAway = () => {
-    if (!isFirstTimeOpen) {
+  const clickAway = (event: Event) => {
+    const isInTranscriptionContent = isEventInElement(
+      event,
+      transcriptionContentId
+    );
+    const isInTakeGroup = isEventInElement(event, takeGroupId);
+
+    if (!isFirstTimeOpen && isInTranscriptionContent && !isInTakeGroup) {
       setIsTakeGroupOpened(false);
     }
   };

--- a/src/renderer/utils/ui.ts
+++ b/src/renderer/utils/ui.ts
@@ -118,3 +118,17 @@ export const letterIndexAtXPosition: (
 };
 
 export const transcriptionContentId = 'transcription-content';
+
+export const isEventInElement: (event: Event, elementId: string) => boolean = (
+  event,
+  elementId
+) => {
+  let elementFound = false;
+
+  event.composedPath().forEach((eventTarget: EventTarget) => {
+    const element = eventTarget as HTMLElement;
+    elementFound = elementFound || element.id === elementId;
+  });
+
+  return elementFound;
+};


### PR DESCRIPTION
### Summary:

* Takes now dont close when you click play or pause or resize the video.
* This helps the user manually preview the content of the take.

### Demo:

https://user-images.githubusercontent.com/86769131/195504071-cdf97709-0c03-48b8-82b9-75d5164bcb50.mp4

### OS

<!-- To select your OS. Place an 'x' within [ ]. eg. - [x] Linux -->

- [x] Linux
- [ ] MacOS
- [ ] Windows
