### PR TITLE
update linux targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,8 @@
     },
     "linux": {
       "target": [
-        "AppImage"
+        "AppImage",
+        "deb"
       ],
       "category": "Development",
       "files": [


### PR DESCRIPTION
Adds the `.deb` target tot the linux build. `.deb` took 16 minutes by itself