### PR TITLE
Update bug-report api url (one line)

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,6 @@
 export const CURRENT_SCHEMA_VERSION = 2;
 export const URL_USER_FEEDBACK_FORM = 'https://forms.gle/YNozsPZxF4kxSuud8';
 export const BUG_REPORT_API_URL =
-  'https://mlvet-bug-reporter-j4v5.vercel.app/api/reportBug';
+  'https://mlvet-bug-reporter-9rvnk7o2o-liamtodd.vercel.app/api/reportBug';
 export const URL_ASSEMBLYAI_SIGNUP =
   'https://app.assemblyai.com/signup?_ga=2.64947567.1548607132.1661819143-2080070454.1661819143';


### PR DESCRIPTION
## Summary

Changed the url for the bug-reporter api because I forked the bug-reporter repo and redeployed the api on vercel on my personal account so it can stay up indefinitely.

<hr/>

### Why is this change needed?
To keep this feature up-and-running indefinitely.

<hr/>

### What did you change?
Just the url for the bug-reporter api.

<hr/>
###Notes
Tested, it works. 0 lines of code changed in the forked bug-reporter repo.


### OS

<!-- To select your OS. Place an 'x' within [ ]. eg. - [x] Linux -->

- [ ] Linux
- [ ] MacOS
- [x] Windows
